### PR TITLE
Pitch page integration

### DIFF
--- a/admin/patreon-options-page.php
+++ b/admin/patreon-options-page.php
@@ -23,6 +23,10 @@ function patreon_plugin_register_settings() { // whitelist options
     register_setting( 'patreon-options', 'patreon-creators-refresh-token' );
     register_setting( 'patreon-options', 'patreon-creator-id' );
     register_setting( 'patreon-options', 'patreon-rewrite-rules-flushed' );
+    //TAO adding own patreon pitch page message on why content cannot be seen
+    register_setting( 'patreon-options', 'tao-patreon-pitch-reason' );
+    //TAO add my own patreon pitch page option.  I also added to the table of options below
+    register_setting( 'patreon-options', 'tao-patreon-pitch-page' );
 }
 
 function patreon_plugin_setup(){
@@ -84,6 +88,16 @@ function patreon_plugin_setup_page(){
         <th scope="row">Creator's Refresh Token</th>
         <td><input type="text" name="patreon-creators-refresh-token" value="<?php echo esc_attr( get_option('patreon-creators-refresh-token', '') ); ?>" class="large-text" /></td>
         </tr>
+        
+        <tr valign="top">
+        <th scope="row">Patreon Pitch Reason</th>
+        <td><input type="text" name="tao-patreon-pitch-reason" value="<?php echo esc_attr( get_option('tao-patreon-pitch-reason', '') ); ?>" class="large-text" /></td>
+        </tr>            
+
+        <tr valign="top">
+        <th scope="row">Patreon Pitch Page</th>
+        <td><input type="url" name="tao-patreon-pitch-page" value="<?php echo esc_attr( get_option('tao-patreon-pitch-page', '') ); ?>" class="large-text" /></td>
+        </tr>        
 
         <?php if(get_option('patreon-creator-id', false)) { ?>
         <tr valign="top">

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -50,11 +50,43 @@ class Patreon_Frontend {
 		
 	}
 
-	public function displayPatreonCampaignBanner() {
+	public function displayPatreonCampaignBanner($patreon_level) {
 
 		/* patreon banner when user patronage not high enough */
 		/* TODO: get marketing collateral */
-		return '<img src="http://placehold.it/500x150?text=PATREON MARKETING COLLATERAL"/>';
+		//return '<img src="http://placehold.it/500x150?text=PATREON MARKETING COLLATERAL"/>';
+
+		//TAO get the patreon pitch page and display it
+		//TAO this is the patreon pitch page
+		$TAO_patreon_pitch_page_url = get_option('tao-patreon-pitch-page', '');
+			//if options comes back with something, then replace the $content		
+			if($TAO_patreon_pitch_page_url)
+				{
+					//I have a full url from the options page, convert that into an DI
+					$TAO_patreon_pitch_page_id  = url_to_postid( $TAO_patreon_pitch_page_url );
+						//the id was found, get the content of that post now
+						if($TAO_patreon_pitch_page_id)
+								{
+									//Display a message for the viewer to usnderstand why they cannot see the content if the option is filled out
+									$TAO_patreon_pitch_reason = get_option('tao-patreon-pitch-reason', '');
+										if($TAO_patreon_pitch_reason)
+												{
+													//check to see if $patreon_level exists in string and replace it with $patreon_level var
+													$TAO_patreon_pitch_reason = str_replace('$patreon_level','$'.$patreon_level,$TAO_patreon_pitch_reason);
+
+													//$content = '[message_box type="note" icon="yes"]' . $TAO_patreon_pitch_reason . '[/message_box][hr]';
+													$content = $TAO_patreon_pitch_reason;
+												}
+									
+
+									//get the content from a post ID, which is the patreon pitch page
+									$content .= get_post_field('post_content', $TAO_patreon_pitch_page_id);
+									return $content;
+
+								}
+				}
+
+
 
 	}
 
@@ -112,8 +144,9 @@ class Patreon_Frontend {
 
 			$user_patronage = Patreon_Wordpress::getUserPatronage();
 
-			if( $user_patronage == false || $user_patronage < ($patreon_level*100) ) {
-				$content = self::displayPatreonCampaignBanner();
+			if( $user_patronage == false || $user_patronage < ($patreon_level) ) {
+				$content = self::displayPatreonCampaignBanner($patreon_level);
+
 			}
 
 		}


### PR DESCRIPTION
This will add options to patreon settings and show a specified pitch page if the user is not a high enough patreon patron.  The pitch page will replace the $content for the protected page.  I hijacked the displayPatreonCampaignBanner() function it interject the pitch page.

P.S. also new at all this GitHub stuff.  My code is hack and slash, so I do expect someone to modify it with some polish and efficiency.  Just trying to help out to get things moving because I want to see if I can use this soon.
