### PR TITLE
Add support for "<!--patreon-->" tag

### DIFF
--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -137,21 +137,16 @@ class Patreon_Frontend {
 			$user_patronage = Patreon_Wordpress::getUserPatronage();
 
 			if( $user_patronage == false || $user_patronage < ($patreon_level*100) ) {
-				if (strpos($content, '<!--patron-->') !== false) {
-				    $content = explode('<!--patron-->', $content)[0];
-				} else {
-					$content = "";
-				}
-
-				$content .= self::displayPatreonCampaignBanner();
+				/* Cuts the content to "<!--patreon-->" slug and displays the button after */
+				/* If the slug doesn't exist, only the button is displayed */
+				$pos = strpos($content, '<!--patreon-->');
+				$pos = $pos ? $pos : 0;
+				$content = substr($content, 0, $pos) . self::displayPatreonCampaignBanner();
 			}
-
 		}
 
 		return $content;
-
 	}
-
 }
 
 ?>

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -137,7 +137,13 @@ class Patreon_Frontend {
 			$user_patronage = Patreon_Wordpress::getUserPatronage();
 
 			if( $user_patronage == false || $user_patronage < ($patreon_level*100) ) {
-				$content = self::displayPatreonCampaignBanner();
+				if (strpos($content, '<!--patron-->') !== false) {
+				    $content = explode('<!--patron-->', $content)[0];
+				} else {
+					$content = "";
+				}
+
+				$content .= self::displayPatreonCampaignBanner();
 			}
 
 		}


### PR DESCRIPTION
Hello!

I'm trying to restrict some content in a WordPress installation for Patron's only. But I didn't thought that creating a "Patreon Content" and then use it as a shortcode in the main article wasn't the best.

So I thought: why not do something like `<!--more-->` but for this? With this small patch, you just have to put a `<!--patreon-->` tag where the Patron's only content starts and everything else will be hidden.

Thanks!
And I hope you find this helpful!
