### PR TITLE
Add action for other plugins to get patreon data

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -71,6 +71,8 @@ class Patreon_Wordpress {
 		update_user_meta($user->ID, 'user_firstname', $user_reponse['data']['attributes']['first_name']);
 		update_user_meta($user->ID, 'user_lastname', $user_reponse['data']['attributes']['last_name']);
 
+		/* give other plugins the chance to use patreon data */
+		do_action( 'patreon_user_data', $user_reponse );
 	}
 
 	public static function getPatreonCreatorID() {


### PR DESCRIPTION
With this action, other plugins can use patreon data, which is not explicitly stored in user_meta. For example, other plugins can check for the pledge amount.