### PR TITLE
Adds support for custom plugin locations so assets resolve

### DIFF
--- a/patreon.php
+++ b/patreon.php
@@ -15,6 +15,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 define("PATREON_PLUGIN_URL", plugin_dir_url( __FILE__ ) );
+define("PATREON_PLUGIN_ASSETS", plugin_dir_url( __FILE__ ) . 'assets' );
 
 include 'admin/patreon-options-page.php';
 include 'admin/patreon-content-metabox.php';


### PR DESCRIPTION
This adds a `define` value for the `PATREON_PLUGIN_ASSETS` variable so that assets resolve. Without this, when scripts and styles are enqueued, they will be set to `mysite.com/js/app.js` instead of `/wp-content/plugins/patreon-wordpress/assets/js/app.js`