### PR TITLE
Add a way to bypass locking level check before patreon flow

### DIFF
--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -26,21 +26,21 @@ class Patreon_Frontend {
 		add_shortcode( 'patreon_login_button', array( $this,'LoginButtonShortcode' ) );
 
 		self::$messages_map = array(
-			'patreon_cant_login_strict_oauth'			 => PATREON_CANT_LOGIN_STRICT_OAUTH,		
-			'login_with_wordpress'						 => PATREON_LOGIN_WITH_WORDPRESS_NOW,		
-			'patreon_nonces_dont_match'					 => PATREON_CANT_LOGIN_NONCES_DONT_MATCH,		
-			'patreon_cant_login_api_error'				 => PATREON_CANT_LOGIN_DUE_TO_API_ERROR,		
+			'patreon_cant_login_strict_oauth'            => PATREON_CANT_LOGIN_STRICT_OAUTH,		
+			'login_with_wordpress'                       => PATREON_LOGIN_WITH_WORDPRESS_NOW,		
+			'patreon_nonces_dont_match'                  => PATREON_CANT_LOGIN_NONCES_DONT_MATCH,		
+			'patreon_cant_login_api_error'               => PATREON_CANT_LOGIN_DUE_TO_API_ERROR,		
 			'patreon_cant_login_api_error_credentials'   => PATREON_CANT_LOGIN_DUE_TO_API_ERROR_CHECK_CREDENTIALS,
 			'patreon_no_locking_level_set_for_this_post' => PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST,
-			'patreon_no_post_id_to_unlock_post'			 => PATREON_NO_POST_ID_TO_UNLOCK_POST,
-			'patreon_weird_redirection_at_login'	     => PATREON_WEIRD_REDIRECTION_AT_LOGIN,		
-			'patreon_could_not_create_wp_account' 		 => PATREON_COULDNT_CREATE_WP_ACCOUNT,		
-			'patreon_api_credentials_missing' 			 => PATREON_API_CREDENTIALS_MISSING,		
-			'admin_login_with_patreon_disabled' 		 => PATREON_ADMIN_LOGIN_WITH_PATREON_DISABLED,		
-			'email_exists_login_with_wp_first' 			 => PATREON_EMAIL_EXISTS_LOGIN_WITH_WP_FIRST,		
-			'login_with_patreon_disabled' 				 => PATREON_LOGIN_WITH_PATREON_DISABLED,		
-			'admin_bypass_filter_message' 				 => PATREON_ADMIN_BYPASSES_FILTER_MESSAGE,		
-			'patreon_direct_unlocks_not_turned_on' 				 => PATREON_DIRECT_UNLOCKS_NOT_ON,
+			'patreon_no_post_id_to_unlock_post'          => PATREON_NO_POST_ID_TO_UNLOCK_POST,
+			'patreon_weird_redirection_at_login'         => PATREON_WEIRD_REDIRECTION_AT_LOGIN,		
+			'patreon_could_not_create_wp_account'        => PATREON_COULDNT_CREATE_WP_ACCOUNT,		
+			'patreon_api_credentials_missing'            => PATREON_API_CREDENTIALS_MISSING,		
+			'admin_login_with_patreon_disabled'          => PATREON_ADMIN_LOGIN_WITH_PATREON_DISABLED,		
+			'email_exists_login_with_wp_first'           => PATREON_EMAIL_EXISTS_LOGIN_WITH_WP_FIRST,		
+			'login_with_patreon_disabled'                => PATREON_LOGIN_WITH_PATREON_DISABLED,		
+			'admin_bypass_filter_message'                => PATREON_ADMIN_BYPASSES_FILTER_MESSAGE,		
+			'patreon_direct_unlocks_not_turned_on'       => PATREON_DIRECT_UNLOCKS_NOT_ON,
 		);
 		
 	}

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -39,7 +39,8 @@ class Patreon_Frontend {
 			'admin_login_with_patreon_disabled' 		 => PATREON_ADMIN_LOGIN_WITH_PATREON_DISABLED,		
 			'email_exists_login_with_wp_first' 			 => PATREON_EMAIL_EXISTS_LOGIN_WITH_WP_FIRST,		
 			'login_with_patreon_disabled' 				 => PATREON_LOGIN_WITH_PATREON_DISABLED,		
-			'admin_bypass_filter_message' 				 => PATREON_ADMIN_BYPASSES_FILTER_MESSAGE,				
+			'admin_bypass_filter_message' 				 => PATREON_ADMIN_BYPASSES_FILTER_MESSAGE,		
+			'patreon_direct_unlocks_not_turned_on' 				 => PATREON_DIRECT_UNLOCKS_NOT_ON,
 		);
 		
 	}

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -307,10 +307,10 @@ class Patreon_Frontend {
 			unset($post);
 			
 			// Set the post to the id if it is given:
-			if ( $args['direct_unlock'] != '' ) {
-				$post = get_post( $args['direct_unlock'] );
+			if ( $args['post_id'] != '' ) {
+				$post = get_post( $args['post_id'] );
 			}
-			
+		
 		}
 		
 		$send_pledge_level = 1;
@@ -350,6 +350,7 @@ class Patreon_Frontend {
 			// If direct unlock request is given, set cacheable flow link vars.
 			$flow_link_args['direct_unlock'] = $args['direct_unlock'];
 			$flow_link_args['redirect'] = $args['redirect'];
+			$flow_link_args['post_id'] = $args['post_id'];
 			
 		}		
 			
@@ -386,9 +387,14 @@ class Patreon_Frontend {
 
 		if ( isset( $args['direct_unlock'] ) ) {
 			
+			$append_post_id = '';
 			// If direct unlock request is given, override all :
 			
-			$flow_link = site_url() . '/patreon-flow/?patreon-direct-unlock=' . $args['direct_unlock'] . '&patreon-redirect=' .  urlencode( base64_encode( $args['redirect'] ) );
+			if( isset( $args['post_id'] ) ) {
+				$append_post_id = '&patreon-post-id=' . $args['post_id'];
+			}
+			
+			$flow_link = site_url() . '/patreon-flow/?patreon-direct-unlock=' . $args['direct_unlock'] . $append_post_id . '&patreon-redirect=' .  urlencode( base64_encode( $args['redirect'] ) );
 			
 		}		
 		
@@ -416,7 +422,7 @@ class Patreon_Frontend {
 		return '<div class="patreon-responsive-button-wrapper"><div class="patreon-responsive-button"><img class="patreon_logo" src="' . PATREON_PLUGIN_ASSETS . '/img/patreon-logomark-on-coral.svg" alt="' . $label . '" /> ' . $label . '</div></div>';
 		
 	}
-	public static function MakeUniversalFlowLink( $pledge_level, $state = false, $client_id = false, $post=false, $args = false )
+	public static function MakeUniversalFlowLink( $pledge_level, $state = false, $client_id = false, $post = false, $args = false )
 	{
 		
 		if ( !$post AND !isset( $args['direct_unlock'] ) ) {
@@ -478,7 +484,7 @@ class Patreon_Frontend {
 		$filterable_utm_params = apply_filters( 'ptrn/utm_params_for_patron_link', $filterable_utm_params );
 		
 		$utm_params = 'utm_source=' . urlencode( site_url() ) . '&utm_medium=patreon_wordpress_plugin&utm_campaign=' . get_option( 'patreon-campaign-id' ) . '&' . $filterable_utm_params;
-		
+
 		return $href . '&' . $utm_params;
 		
 	}

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -189,7 +189,10 @@ class Patreon_Routing {
 						
 					}
 		
-					if( $patreon_level == 0 ) {
+					if( $patreon_level == 0  
+						AND !( isset($GLOBALS['patreon_skip_unlock_redirect_level_check']) 
+								AND $GLOBALS['patreon_skip_unlock_redirect_level_check'] )
+					) {
 						
 						// No locking level set for this content or the site. No point in locking. Redirect to post.
 						$final_redirect = add_query_arg( 'patreon_message', 'patreon_no_locking_level_set_for_this_post', $final_redirect );

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -122,7 +122,20 @@ class Patreon_Routing {
 			
 			if( array_key_exists( 'patreon-direct-unlock', $wp->query_vars ) ) {
 				
+				$final_redirect = wp_login_url();
+				
 				if( isset( $wp->query_vars['patreon-direct-unlock'] ) ) {
+					
+					if( !( isset($GLOBALS['patreon_skip_unlock_redirect_level_check']) 
+								AND $GLOBALS['patreon_skip_unlock_redirect_level_check'] )
+					) {
+						
+						// No locking level set for this content or the site. No point in locking. Redirect to post.
+						$final_redirect = add_query_arg( 'patreon_message', 'patreon_direct_unlocks_not_turned_on', $final_redirect );
+						wp_redirect( $final_redirect );
+						
+						exit;	
+					}					
 					
 					$patreon_level = $wp->query_vars['patreon-direct-unlock'];
 					$redirect = base64_decode( urldecode( $wp->query_vars['patreon-redirect'] ) );

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -248,8 +248,7 @@ class Patreon_Routing {
 					}
 		
 					if( $patreon_level == 0  
-						AND !( isset($GLOBALS['patreon_enable_direct_unlocks']) 
-								AND $GLOBALS['patreon_enable_direct_unlocks'] )
+						AND !( isset($GLOBALS['patreon_enable_direct_unlocks']) AND $GLOBALS['patreon_enable_direct_unlocks'] )
 					) {
 						
 						// No locking level set for this content or the site. No point in locking. Redirect to post.

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -126,8 +126,7 @@ class Patreon_Routing {
 				
 				if( isset( $wp->query_vars['patreon-direct-unlock'] ) ) {
 					
-					if( !( isset($GLOBALS['patreon_skip_unlock_redirect_level_check']) 
-								AND $GLOBALS['patreon_skip_unlock_redirect_level_check'] )
+					if( !( isset($GLOBALS['patreon_enable_direct_unlocks']) AND $GLOBALS['patreon_enable_direct_unlocks'] )
 					) {
 						
 						// No locking level set for this content or the site. No point in locking. Redirect to post.
@@ -249,8 +248,8 @@ class Patreon_Routing {
 					}
 		
 					if( $patreon_level == 0  
-						AND !( isset($GLOBALS['patreon_skip_unlock_redirect_level_check']) 
-								AND $GLOBALS['patreon_skip_unlock_redirect_level_check'] )
+						AND !( isset($GLOBALS['patreon_enable_direct_unlocks']) 
+								AND $GLOBALS['patreon_enable_direct_unlocks'] )
 					) {
 						
 						// No locking level set for this content or the site. No point in locking. Redirect to post.

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -66,6 +66,7 @@ class Patreon_Routing {
 		array_push( $public_query_vars, 'patreon-unlock-post' );
 		array_push( $public_query_vars, 'patreon-unlock-image' );
 		array_push( $public_query_vars, 'patreon-direct-unlock' );
+		array_push( $public_query_vars, 'patreon-post-id' );
 		array_push( $public_query_vars, 'patreon-login' );
 		array_push( $public_query_vars, 'patreon-final-redirect' );
 		array_push( $public_query_vars, 'code' );
@@ -143,11 +144,18 @@ class Patreon_Routing {
 						
 					}
 					
+					$post = false;
+					
+					// If post id set, get the post 
+					if( isset( $wp->query_vars['patreon-post-id'] ) ) {
+						$post = get_post( $wp->query_vars['patreon-post-id'] );
+					}
+					
 					$link_interface_item         = 'direct_unlock_button';
 					$state['final_redirect_uri'] = $redirect;	
 					$send_pledge_level           = $patreon_level * 100;
-		
-					$flow_link = Patreon_Frontend::MakeUniversalFlowLink( $send_pledge_level, $state, $client_id, false, array('link_interface_item' => $link_interface_item ) );
+					
+					$flow_link = Patreon_Frontend::MakeUniversalFlowLink( $send_pledge_level, $state, $client_id, $post, array('link_interface_item' => $link_interface_item ) );
 
 					wp_redirect( $flow_link );
 					exit;

--- a/patreon.php
+++ b/patreon.php
@@ -67,6 +67,8 @@ These include your Patreon user id, Patreon username, your first, last names and
 <br /><br />
 If you request that your data be deleted from this website, this data will also be deleted and Patreon functionality will not work. You would need to register on this website and log in to this website with Patreon again in order to re-populate this data and have Patreon functionality working again.' );
 
+define( "PATREON_DIRECT_UNLOCKS_NOT_ON", 'Direct unlocks need to be turned on for using this feature. Please refer to developer documentation. If you see this message, please inform site administration.' );
+
 include 'classes/patreon_wordpress.php';
 
 $Patreon_Wordpress = new Patreon_Wordpress;

--- a/patreon.php
+++ b/patreon.php
@@ -67,7 +67,7 @@ These include your Patreon user id, Patreon username, your first, last names and
 <br /><br />
 If you request that your data be deleted from this website, this data will also be deleted and Patreon functionality will not work. You would need to register on this website and log in to this website with Patreon again in order to re-populate this data and have Patreon functionality working again.' );
 
-define( "PATREON_DIRECT_UNLOCKS_NOT_ON", 'Direct unlocks need to be turned on for using this feature. Please refer to developer documentation. If you see this message, please inform site administration.' );
+define( "PATREON_DIRECT_UNLOCKS_NOT_ON", 'In order to use this feature, direct unlocks need to be turned on. Please refer to <a href="https://www.patreon.com/apps/wordpress">the developer documentation</a>. ' );
 
 include 'classes/patreon_wordpress.php';
 


### PR DESCRIPTION
**Problem**

Existing locking and unlock flow logic was built around posts. This doesnt allow locking any non-post content in websites. Ie, you cant lock a content shown in header, a content that comes from a meta value attached to a non locked post, a non post (or custom post) page, category listing pages or search listing pages, or forum category pages and so on.

**Solution**

This PR adds args to the functions that create the interface, an additional flow slug to enable non-post unlock requests, and a routing logic to check, process and send the user to patreon flow, and receive him/her back.

A developer or site owner can turn on this feature by toggling a global var in a plugin or theme's functions php, which enables this feature. This toggle helps non-technical site users from using this feature and causing more bots/crawlers to find dynamic urls and follow non-post unlock requests to Patreon API. If there is demand for it in future from many non technical users, we may introduce this toggle as an option, for now its fit to have it as something that needs to be toggled by a developer.

Now that interface generating functions can be used without being tied to a locked post id by passing various arguments to generate an interface anywhere, any site owner can lock any content anywhere. This allows locking of content inside header, footer, widgets, or, even inside post content through embedding of code. Additionally this will bypass issues like plugin not being able to lock content when a theme shows content outside the the_content filter (normal post/page main content element), or webcomic or visual plugins which show visual content outside the_content, like header, or a custom meta box and the line.

Additionally this feature allows interface generating function to be used in custom listings or interfaces by passing post ids and requesting direct unlock.

**Verification**

User Acceptance Testing is already done and confirmed to work at pat.codebard.com . Visuals are below.

View of a generated custom interface locking custom content inside header, in a page which has locked content itself. The new cacheable link format generated by the same functions for this interface can be seen at the bottom. It includes final redirect so devs/site owners can redirect users anywhere they want at the end.

![view-of-custom-locked-content-in-header-with-new-cacheable-link-shown-below](https://user-images.githubusercontent.com/13155428/43348952-11447106-91fd-11e8-980f-32a349e3bfed.jpg)

At the end of the unlock flow, ending up with the same url that was started from. Because the user pledges $7, s/he is able to unlock both the content in header (which was set at $7), and the post content (which was set at $5). The new feature allows these content to be locked independently.

![both-header-and-post-contents-unlocked-with-the-direct-flow-link](https://user-images.githubusercontent.com/13155428/43348997-4137a752-91fd-11e8-8ff9-85e858e8d4b4.jpg)

An error message is displayed if a site owner does not turn on this feature by toggling a global in a file, but still wants to use it.

![ze_error_message](https://user-images.githubusercontent.com/13155428/43349029-66520c76-91fd-11e8-84e5-b031e8d1e12e.jpg)

**Does this need tests**

UAC was already done, and confirmed to work with normal post locking. There is no unit test written for this feature at this time. 