### PR TITLE
Two cases in patreon authorization and flow are covered with error messages against unlikely errors

### DIFF
--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -26,20 +26,22 @@ class Patreon_Frontend {
 		add_shortcode( 'patreon_login_button', array( $this,'LoginButtonShortcode' ) );
 
 		self::$messages_map = array(
-			'patreon_cant_login_strict_oauth'			 => PATREON_CANT_LOGIN_STRICT_OAUTH,		
-			'login_with_wordpress'						 => PATREON_LOGIN_WITH_WORDPRESS_NOW,		
-			'patreon_nonces_dont_match'					 => PATREON_CANT_LOGIN_NONCES_DONT_MATCH,		
-			'patreon_cant_login_api_error'				 => PATREON_CANT_LOGIN_DUE_TO_API_ERROR,		
+			'patreon_cant_login_strict_oauth'            => PATREON_CANT_LOGIN_STRICT_OAUTH,		
+			'login_with_wordpress'                       => PATREON_LOGIN_WITH_WORDPRESS_NOW,		
+			'patreon_nonces_dont_match'                  => PATREON_CANT_LOGIN_NONCES_DONT_MATCH,		
+			'patreon_cant_login_api_error'               => PATREON_CANT_LOGIN_DUE_TO_API_ERROR,		
 			'patreon_cant_login_api_error_credentials'   => PATREON_CANT_LOGIN_DUE_TO_API_ERROR_CHECK_CREDENTIALS,
 			'patreon_no_locking_level_set_for_this_post' => PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST,
-			'patreon_no_post_id_to_unlock_post'			 => PATREON_NO_POST_ID_TO_UNLOCK_POST,
-			'patreon_weird_redirection_at_login'	     => PATREON_WEIRD_REDIRECTION_AT_LOGIN,		
-			'patreon_could_not_create_wp_account' 		 => PATREON_COULDNT_CREATE_WP_ACCOUNT,		
-			'patreon_api_credentials_missing' 			 => PATREON_API_CREDENTIALS_MISSING,		
-			'admin_login_with_patreon_disabled' 		 => PATREON_ADMIN_LOGIN_WITH_PATREON_DISABLED,		
-			'email_exists_login_with_wp_first' 			 => PATREON_EMAIL_EXISTS_LOGIN_WITH_WP_FIRST,		
-			'login_with_patreon_disabled' 				 => PATREON_LOGIN_WITH_PATREON_DISABLED,		
-			'admin_bypass_filter_message' 				 => PATREON_ADMIN_BYPASSES_FILTER_MESSAGE,				
+			'patreon_no_post_id_to_unlock_post'          => PATREON_NO_POST_ID_TO_UNLOCK_POST,
+			'patreon_weird_redirection_at_login'         => PATREON_WEIRD_REDIRECTION_AT_LOGIN,		
+			'patreon_could_not_create_wp_account'        => PATREON_COULDNT_CREATE_WP_ACCOUNT,		
+			'patreon_api_credentials_missing'            => PATREON_API_CREDENTIALS_MISSING,		
+			'admin_login_with_patreon_disabled'          => PATREON_ADMIN_LOGIN_WITH_PATREON_DISABLED,		
+			'email_exists_login_with_wp_first'           => PATREON_EMAIL_EXISTS_LOGIN_WITH_WP_FIRST,		
+			'login_with_patreon_disabled'                => PATREON_LOGIN_WITH_PATREON_DISABLED,		
+			'admin_bypass_filter_message'                => PATREON_ADMIN_BYPASSES_FILTER_MESSAGE,
+			'no_code_receved_from_patreon'               => PATREON_NO_CODE_RECEIVED_FROM_PATREON,
+			'no_patreon_action_provided_for_flow'                 => PATREON_NO_FLOW_ACTION_PROVIDED,
 		);
 		
 	}

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -109,7 +109,7 @@ class Patreon_Routing {
 
 				wp_redirect( $login_url );
 				exit;
-				
+			
 			}
 			
 			if( array_key_exists( 'patreon-unlock-post', $wp->query_vars ) ) {
@@ -225,7 +225,8 @@ class Patreon_Routing {
 			}
 			
 			// Catch all
-			wp_redirect( home_url() );
+			$redirect = add_query_arg( 'patreon_message', 'no_patreon_action_provided_for_flow', wp_login_url() );
+			wp_redirect( $redirect );
 			exit;
 			
 		}
@@ -312,7 +313,8 @@ class Patreon_Routing {
 				
 			} else {
 				
-				wp_redirect( home_url() );
+				$redirect = add_query_arg( 'patreon_message', 'no_code_receved_from_patreon', wp_login_url() );
+				wp_redirect( $redirect );
 				exit;
 				
 			}

--- a/patreon.php
+++ b/patreon.php
@@ -66,6 +66,8 @@ define( "PATREON_PRIVACY_POLICY_ADDENDUM", '<h2>Patreon features in this website
 These include your Patreon user id, Patreon username, your first, last names and your vanity name. Additionally, the id of your campaign at Patreon and your campaign\'s Patreon URL are also saved.
 <br /><br />
 If you request that your data be deleted from this website, this data will also be deleted and Patreon functionality will not work. You would need to register on this website and log in to this website with Patreon again in order to re-populate this data and have Patreon functionality working again.' );
+define( "PATREON_NO_CODE_RECEIVED_FROM_PATREON", "Sorry -  No authorization code received from Patreon." );
+define( "PATREON_NO_FLOW_ACTION_PROVIDED", "Nothing to do since no Patreon action was requested." );
 
 include 'classes/patreon_wordpress.php';
 


### PR DESCRIPTION
**Problem**

There are 2 cases in routing/authorization class which are not covered by error messages. This leads to some creators complaining about users going through the unlock flow but nothing happening when these cases trigger.

One case is a user being redirected to /patreon-authorization/ slug/page without any proper authorization code return from Patreon. This can happen when Patreon doesnt return any code due to any particular reason, the WP website loses the code in between redirects (especially redirection plugins, or security setups like overzealous mod_security, or security plugins may be culprits) or any other unknown setup at a particular WP site. 

The second case is when a user is directed to /patreon-flow/ slug/page without any request like unlock-post or login. This can end up happening due to similar reasons like the above. 

Result is user being directed to the page s/he started from or the main page without any message or notification without the post or content being unlocked. Which then leads to a perception of the plugin 'not working', which then leads to support incidents.

**Solution**

These simple changes add 2 error messages to these conditions and redirects the users to wp-login page in order to display the error message. 

**Verification**

UAC done, works. It can be reproduced by simply visiting domain.com/patreon-flow/ and domain.com/patreon-authorization/ pages by directly putting the urls in the browser bar in a site where this branch is installed. The 2 different messages are included in screenshots below.

![message-1](https://user-images.githubusercontent.com/13155428/43740600-f6ad183a-99cb-11e8-978e-a2701d99213e.jpg)

![message-2](https://user-images.githubusercontent.com/13155428/43740603-fb4c9a50-99cb-11e8-9ef1-cb8326b25748.jpg)

**Does this need tests**

UAC was already done, and confirmed to work. There is no unit test written for this change or relevant functions at this time.

