### PR TITLE
Add hooks filters to login and unlock

### DIFF
--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -98,6 +98,17 @@ class Patreon_Login {
 			$user = wp_get_current_user();
 						
 			self::updateExistingUser( $user->ID, $user_response, $tokens );
+
+			// Below filter vars and the following filter allows plugin devs to acquire/filter info about Patron/user after the user returns from Patreon
+			
+			$filter_args = array(
+				'user' => $user,
+				'action_type' => 'login_existing_user',
+				'redirect' => $redirect,
+			);
+			
+			apply_filters( 'patreon_filter_vars_after_patreon_login', $filter_args );		
+			
 			wp_redirect( $redirect );
 			exit;
 						
@@ -132,7 +143,7 @@ class Patreon_Login {
 			
 			foreach ( $patreon_linked_accounts as $key => $value ) {
 				
-				$last_logged_in = get_user_meta( $patreon_linked_accounts[$key]['user_id'],'patreon_last_logged_in', true );
+				$last_logged_in = get_user_meta( $patreon_linked_accounts[$key]['user_id'], 'patreon_last_logged_in', true );
 		
 				$sort_logins[ $patreon_linked_accounts[ $key ]['user_id'] ] = $last_logged_in;
 				
@@ -162,8 +173,18 @@ class Patreon_Login {
 					/* log user into existing wordpress account with matching username */
 					wp_set_current_user( $user->ID, $user->user_login );
 					wp_set_auth_cookie( $user->ID );
-					do_action( 'wp_login', $user->user_login, $user );	
+					do_action( 'wp_login', $user->user_login, $user );
+
+					// Below filter vars and the following filter allows plugin devs to acquire/filter info about Patron/user after the user returns from Patreon
 					
+					$filter_args = array(
+						'user' => $user,
+						'action_type' => 'create_and_login_new_user',
+						'redirect' => $redirect,
+					);
+					
+					apply_filters( 'patreon_filter_vars_after_patreon_user_create_and_login', $filter_args );		
+						
 					/* update user meta data with patreon data */
 					self::updateExistingUser( $user->ID, $user_response, $tokens );
 					wp_redirect( $redirect );

--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -103,11 +103,10 @@ class Patreon_Login {
 			
 			$filter_args = array(
 				'user' => $user,
-				'action_type' => 'login_existing_user',
 				'redirect' => $redirect,
 			);
 			
-			apply_filters( 'patreon_filter_vars_after_patreon_login', $filter_args );		
+			do_action( 'patreon_action_after_wp_logged_user_is_updated', $filter_args );		
 			
 			wp_redirect( $redirect );
 			exit;
@@ -179,11 +178,10 @@ class Patreon_Login {
 					
 					$filter_args = array(
 						'user' => $user,
-						'action_type' => 'create_and_login_new_user',
 						'redirect' => $redirect,
 					);
 					
-					apply_filters( 'patreon_filter_vars_after_patreon_user_create_and_login', $filter_args );		
+					do_action( 'patreon_do_action_after_user_logged_in_via_patreon', $filter_args );					
 						
 					/* update user meta data with patreon data */
 					self::updateExistingUser( $user->ID, $user_response, $tokens );
@@ -282,6 +280,15 @@ class Patreon_Login {
 				wp_set_current_user( $user->ID, $user->data->user_login );
 				wp_set_auth_cookie( $user->ID );
 				do_action( 'wp_login', $user->data->user_login, $user );
+				
+				// Below filter vars and the following filter allows plugin devs to acquire/filter info about Patron/user after the user returns from Patreon
+				
+				$filter_args = array(
+					'user' => $user,
+					'redirect' => $redirect,
+				);
+				
+				do_action( 'patreon_do_action_after_new_user_created_from_patreon_logged_in', $filter_args );				
 
 				/* update user meta data with patreon data */
 				self::updateExistingUser( $user->ID, $user_response, $tokens );	

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -112,7 +112,7 @@ class Patreon_Routing {
 					'user' => wp_get_current_user(),
 				);
 				
-				apply_filters( 'patreon_filter_vars_before_patreon_login', $filter_args );				
+				do_action( 'patreon_do_action_before_patreon_login', $filter_args );				
 			
 				$login_url = Patreon_Frontend::patreonMakeLoginLink( false, $state );
 
@@ -236,7 +236,7 @@ class Patreon_Routing {
 						'user' => wp_get_current_user(),
 					);
 					
-					apply_filters( 'patreon_filter_vars_before_universal_flow', $filter_args );
+					do_action( 'patreon_do_action_before_universal_flow', $filter_args );
 					
 					$flow_link = Patreon_Frontend::MakeUniversalFlowLink( $send_pledge_level, $state, $client_id, false, array('link_interface_item' => $link_interface_item ) );
 				

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -104,6 +104,15 @@ class Patreon_Routing {
 				$state = array(
 					'final_redirect_uri' => $final_redirect,
 				);
+				
+				// Below filter vars and the following filter allows plugin devs to acquire/filter info about Patron/user + content before going to Patreon flow
+				
+				$filter_args = array(
+					'state' => $state,
+					'user' => wp_get_current_user(),
+				);
+				
+				apply_filters( 'patreon_filter_vars_before_patreon_login', $filter_args );				
 			
 				$login_url = Patreon_Frontend::patreonMakeLoginLink( false, $state );
 
@@ -215,6 +224,20 @@ class Patreon_Routing {
 
 					$send_pledge_level = $patreon_level * 100;
 					
+					// Below filter vars and the following filter allows plugin devs to acquire/filter info about Patron/user + content before going to Patreon flow
+					
+					$filter_args = array(
+						'link_interface_item' => $link_interface_item, 
+						'post' => $post,
+						'post_level' => $post_level,
+						'patreon_level' => $patreon_level,
+						'state' => $state,
+						'state' => $state,
+						'user' => wp_get_current_user(),
+					);
+					
+					apply_filters( 'patreon_filter_vars_before_universal_flow', $filter_args );
+					
 					$flow_link = Patreon_Frontend::MakeUniversalFlowLink( $send_pledge_level, $state, $client_id, false, array('link_interface_item' => $link_interface_item ) );
 				
 					wp_redirect( $flow_link );
@@ -295,7 +318,7 @@ class Patreon_Routing {
 					$api_client = new Patreon_API( $tokens['access_token'] );
 					
 					$user_response = $api_client->fetch_user();
-
+					
 					if( apply_filters( 'ptrn/force_strict_oauth', get_option( 'patreon-enable-strict-oauth', false ) ) ) {
 						$user = Patreon_Login::updateLoggedInUserForStrictoAuth( $user_response, $tokens, $redirect );
 					} else {


### PR DESCRIPTION
**Problem**

Add action hooks before sending users to Patreon (login, user creation, unlock) and after receiving them back from Patreon (login, user creation, unlock) to allow 3rd party plugins to hook into these processes and receive variables that can be used for creating addons.

Potential use case examples:

A statistic plugin which will collect stats on performance of locked posts and patron preferences may hook into these actions and then use it to collect statistics. 

Or, a custom code or addon/plugin can hook into these hooks and use them to run after-login and after user creation processes.

**Solution**

do_action callback was added to run specifically named actions, while providing to 3rd party plugins variables regarding the current action, current user, important data like post object, final redirect location.

**Verification**

Actions were tested for each case to confirm they run and provide the variables desired. Using this branch any below action can be hooked to by any 3rd party code to reproduce and confirm.

patreon_do_action_before_patreon_login
patreon_do_action_before_universal_flow
patreon_action_after_wp_logged_user_is_updated
patreon_do_action_after_user_logged_in_via_patreon
patreon_do_action_after_new_user_created_from_patreon_logged_in

**Does this need tests**

UAC done, works, no unit tests are present for this change at this time.