### PR TITLE
Removed rogue function call causing creator url check to fire on every admin page load instead of only when creator url is not found

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -206,7 +206,6 @@ class Patreon_Wordpress {
 	public static function checkPatreonCreatorURL() {
 		
 		// Check if creator url doesnt exist. 
-		$creator_url = self::getPatreonCreatorURL();
 		
 		if ( !get_option( 'patreon-creator-url', false ) OR get_option( 'patreon-creator-url', false ) == '' ) {
 			


### PR DESCRIPTION
Problem

An extra line to creator url fetch function is causing Patreon API to be contacted on every admin page load instead of only when creator url is not found in the database - leading to unnecessary API load and also page load speed slowdown

Solution

Removing the line with the rogue function call fixes the always-triggered check issue

Verification

Making fetch_creator_info in patreon_api.php to print out debug information shows when creator info is requested for this action. With the fix, it doesnt trigger unless the creator url is not found in db.

Does this need tests

Manual test done, works. No unit test is written for this feature yet.