### PR TITLE
Add admin warning in case api access error due to auth

### DIFF
--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -130,9 +130,4 @@ class Patreon_API {
 		return $this->__get_json( "campaigns?include=rewards,creator,goals", true );
 	}
 	
-	public function check_api_access() {
-		// Checks if api can be contacted with existing credentials and returns the result
-		return $this->__get_json( "current_user/campaigns?include=rewards,creator,goals,pledges" );
-	}
-	
 }

--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -99,7 +99,7 @@ class Patreon_API {
 		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
 			$api_endpoint = "https://www.patreon.com/api/oauth2/v2/" . $suffix;	
 		}
-	
+
 		$headers = array(
 			'Authorization' => 'Bearer ' . $this->access_token,
 			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
@@ -132,7 +132,7 @@ class Patreon_API {
 	
 	public function check_api_access() {
 		// Checks if api can be contacted with existing credentials and returns the result
-		return $this->__get_json( "current_user/campaigns?include=creator", true );
+		return $this->__get_json( "current_user/campaigns?include=rewards,creator,goals,pledges" );
 	}
 	
 }

--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -129,4 +129,10 @@ class Patreon_API {
 		// Transitional function - checks if api v2 can be contacted with existing credentials and returns the result
 		return $this->__get_json( "campaigns?include=rewards,creator,goals", true );
 	}
+	
+	public function check_api_access() {
+		// Checks if api can be contacted with existing credentials and returns the result
+		return $this->__get_json( "current_user/campaigns?include=creator", true );
+	}
+	
 }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -306,24 +306,9 @@ class Patreon_Wordpress {
 				
 				if ( $error['code'] == 1 ) {
 
-					/* refresh creators token if error 1 */
-					$refresh_token = get_option( 'patreon-creators-refresh-token', false );
-
-					if( $refresh_token == false ) {
-						return false;
+					if(self::refresh_creator_access_token()) {
+						return $api_client->fetch_creator_info();
 					}
-
-					$oauth_client = new Patreon_Oauth;
-					$tokens       = $oauth_client->refresh_token( $refresh_token, site_url() . '/patreon-authorization/' );
-
-					if( isset( $tokens['refresh_token'] ) && isset( $tokens['access_token'] ) ) {
-						
-						update_option( 'patreon-creators-refresh-token', $tokens['refresh_token'] );
-						update_option( 'patreon-creators-access-token', $tokens['access_token'] );
-						
-					}
-
-					$user_response = $api_client->fetch_creator_info();
 					
 				}
 				
@@ -331,8 +316,28 @@ class Patreon_Wordpress {
 			
 		}
 		
-		return $user_response;
+		return false;
 		
+	}
+	public static function refresh_creator_access_token() {
+		/* refresh creators token if error 1 */
+		$refresh_token = get_option( 'patreon-creators-refresh-token', false );
+
+		if( $refresh_token == false ) {
+			return false;
+		}
+
+		$oauth_client = new Patreon_Oauth;
+		$tokens       = $oauth_client->refresh_token( $refresh_token, site_url() . '/patreon-authorization/' );
+
+		if( isset( $tokens['refresh_token'] ) && isset( $tokens['access_token'] ) ) {
+			
+			update_option( 'patreon-creators-refresh-token', $tokens['refresh_token'] );
+			update_option( 'patreon-creators-access-token', $tokens['access_token'] );
+			return true;
+		}		
+		
+		return false;
 	}
 	public static function getPatreonCreatorID() {
 


### PR DESCRIPTION
**Problem**

When API credentials were wrong or creator's access token was expired and API could not be contacted, the plugin wasnt giving any warning to the site owner. This led to support incidents due to working sites  having their tokens expired without any warning.

**Solution**

A new function checks api connection with the given app credentials and creator's access token on every page load, if it receives 401 unauthorized, attempts to refresh creator's access token, and if still fails to connect after that, queues an error message for the WP admins on WP admin pages. The error message is persistent and only goes away automatically after plugin is able to contact Patreon API without 401 unauthorized error.

![api-credentials-warning](https://user-images.githubusercontent.com/13155428/44467891-5763ec80-a624-11e8-9a66-d958cf0a4d1d.jpg)

**Verification**

Making the api connection fail through any way triggers creator's token refresh attempt (tested), and if it fails queues the error message. 

**Does this need tests**

Manual test done, works. No unit test is written for this feature yet.