### PR TITLE
Add admin side update available notice

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -31,7 +31,8 @@ jQuery( function( $ ) {
 				}
 			});
 		})
-	}, 1000 );		
+	}, 1000 );
+	
 	jQuery( document ).on( 'submit', '#patreon_attachment_patreon_level_form', function( e ) {
 		e.preventDefault();
 		jQuery.ajax({
@@ -45,8 +46,13 @@ jQuery( function( $ ) {
 			}
 		});	
 	});
+	
 	// Need to bind to event after tinymce is initialized - so we hook to all tinymce instances after a timeout
 	setTimeout( function () {
+		
+		if( typeof tinymce === 'undefined' ) {
+			return;
+		}
 		for ( var i = 0; i < tinymce.editors.length; i++ ) {
 			
 			tinymce.editors[i].on( 'click', function ( e ) {
@@ -77,5 +83,19 @@ jQuery( function( $ ) {
 					}
 			});
 		}
-	}, 1000);	
+	}, 1000);
+
+	jQuery(document).on( 'click', '.patreon-wordpress .notice-dismiss', function(e) {
+
+		jQuery.ajax({
+			url: ajaxurl,
+			type:"POST",
+			dataType : 'html',
+			data: {
+				action: 'patreon_wordpress_dismiss_admin_notice',
+				notice_id: jQuery( this ).parent().attr( "id" ),
+			}
+		});
+	});	
+	
 });

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -724,7 +724,9 @@ class Patreon_Wordpress {
 			return $plugin_check_data;
 		}
 
-		if ( isset( $plugin_check_data->response[PATREON_WORDPRESS_PLUGIN_SLUG] ) AND version_compare( PATREON_WORDPRESS_VERSION, $plugin_check_data->response[PATREON_WORDPRESS_PLUGIN_SLUG]->new_version, '<' ) ) {
+		if ( isset( $plugin_check_data->response[PATREON_WORDPRESS_PLUGIN_SLUG] ) AND 
+			version_compare( PATREON_WORDPRESS_VERSION, $plugin_check_data->response[PATREON_WORDPRESS_PLUGIN_SLUG]->new_version, '<' )
+		) {
 
 			update_option( 'patreon-wordpress-update-available', 1 );
 		}

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -55,6 +55,7 @@ class Patreon_Wordpress {
 		add_action( 'init', array( $this, 'transitionalImageOptionCheck' ) );
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_section' ), 20 ) ;
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ) );
+		add_action( 'wp_ajax_patreon_wordpress_dismiss_admin_notice', array( $this, 'dismiss_admin_notice' ), 10, 1 );
 
 	}
 	public static function getPatreonUser( $user ) {
@@ -706,7 +707,7 @@ class Patreon_Wordpress {
 		if( get_option( 'patreon-wordpress-update-available', false ) ) {
 			
 			?>
-				 <div class="notice notice-info is-dismissible">
+				 <div class="notice notice-info is-dismissible patreon-wordpress" id="patreon-wordpress-update-available">
 				 <h3>New version of Patreon WordPress is available</h3>
 					<p>To be able to receive the latest features, security and bug fixes, please update your plugin by <a href="<?php echo wp_nonce_url( get_admin_url() . 'update.php?action=upgrade-plugin&plugin=' . PATREON_WORDPRESS_PLUGIN_SLUG,'upgrade-plugin_' . PATREON_WORDPRESS_PLUGIN_SLUG ); ?>">clicking here</a>.</p>
 				</div>
@@ -730,6 +731,18 @@ class Patreon_Wordpress {
 
 		return $plugin_check_data;
 		
+	}	
+	public function dismiss_admin_notice() 
+	{
+		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
+			return;
+		}
+		
+		// Mapping what comes from REQUEST to a given value avoids potential security problems
+		if ( $_REQUEST['notice_id'] == 'patreon-wordpress-update-available' ) {
+			delete_option( 'patreon-wordpress-update-available');
+		}
+
 	}	
 	
 }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -54,6 +54,7 @@ class Patreon_Wordpress {
 		add_action( 'admin_notices', array( $this, 'AdminMessages' ) );
 		add_action( 'init', array( $this, 'transitionalImageOptionCheck' ) );
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_section' ), 20 ) ;
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ) );
 
 	}
 	public static function getPatreonUser( $user ) {
@@ -206,6 +207,7 @@ class Patreon_Wordpress {
 	public static function checkPatreonCreatorURL() {
 		
 		// Check if creator url doesnt exist. 
+		$creator_url = self::getPatreonCreatorURL();
 		
 		if ( !get_option( 'patreon-creator-url', false ) OR get_option( 'patreon-creator-url', false ) == '' ) {
 			
@@ -687,7 +689,7 @@ class Patreon_Wordpress {
 			update_option( 'patreon-file-locking-feature-notice-shown', 1 );
 			
 		}
-			
+		
 		if( !get_option( 'patreon-gdpr-notice-shown', false ) ) {
 			
 			?>
@@ -701,6 +703,33 @@ class Patreon_Wordpress {
 			
 		}
 		
+		if( get_option( 'patreon-wordpress-update-available', false ) ) {
+			
+			?>
+				 <div class="notice notice-info is-dismissible">
+				 <h3>New version of Patreon WordPress is available</h3>
+					<p>To be able to receive the latest features, security and bug fixes, please update your plugin by <a href="<?php echo wp_nonce_url( get_admin_url() . 'update.php?action=upgrade-plugin&plugin=' . PATREON_WORDPRESS_PLUGIN_SLUG,'upgrade-plugin_' . PATREON_WORDPRESS_PLUGIN_SLUG ); ?>">clicking here</a>.</p>
+				</div>
+			<?php
+			
+		}
+		
 	}
+	public function check_for_update($plugin_check_data) 
+	{
+		global $wp_version, $plugin_version, $plugin_base;
+
+		if ( empty( $plugin_check_data->checked ) ) {
+			return $plugin_check_data;
+		}
+
+		if ( isset( $plugin_check_data->response[PATREON_WORDPRESS_PLUGIN_SLUG] ) AND version_compare( PATREON_WORDPRESS_VERSION, $plugin_check_data->response[PATREON_WORDPRESS_PLUGIN_SLUG]->new_version, '<' ) ) {
+
+			update_option( 'patreon-wordpress-update-available', 1 );
+		}
+
+		return $plugin_check_data;
+		
+	}	
 	
 }

--- a/patreon.php
+++ b/patreon.php
@@ -4,7 +4,7 @@
 Plugin Name: Patreon Wordpress
 Plugin URI: https://www.patreon.com/apps/wordpress
 Description: Patron-only content, directly on your website.
-Version: 1.1.2
+Version: 1.1.1
 Author: Patreon <platform@patreon.com>
 Author URI: https://patreon.com
 */
@@ -59,7 +59,7 @@ define( "PATREON_ADMIN_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons on
 define( "PATREON_CREATOR_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons only, it\'s not locked for you because you are logged in as the Patreon creator' );
 define( "PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST", 'Post is already public. If you would like to lock this post, please set a pledge level for it' );
 define( "PATREON_NO_POST_ID_TO_UNLOCK_POST", 'Sorry - could not get the post id for this locked post' );
-define( "PATREON_WORDPRESS_VERSION", '1.1.3' );
+define( "PATREON_WORDPRESS_VERSION", '1.1.1' );
 define( "PATREON_WORDPRESS_PLUGIN_SLUG", plugin_basename( __FILE__ ) );
 define( "PATREON_PRIVACY_POLICY_ADDENDUM", '<h2>Patreon features in this website</h2>In order to enable you to use this website with Patreon services, we save certain functionally important Patreon information about you in this website if you log in with Patreon.
 <br /><br />

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressorg@patreon.com, codebard
 Tags: patreon, membership, members
 Requires at least: 4.0
 Tested up to: 4.9.6
-Stable tag: 1.1.2
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
**Problem**

The plugin lacks the commonplace plugin update available notice as found in other mainstream plugins. Users do not upgrade their versions, and ask for support for issues in old versions - leading to users both experiencing problems which were fixed in later versions and not being able to use new features. Visible update notices in admin pages are used by many plugins to notify users who dont regularly go to plugins page to be aware of availability of an update and then update their plugin.

**Solution**

An update available notice with a link for directly updating the plugin with a single click added.

![update-notice](https://user-images.githubusercontent.com/13155428/44667311-ba85c280-aa1a-11e8-91d3-243043699a2c.jpg)

Notice appears when WP makes a plugin version check and there is a new version available. Persists across all WP admin pages. It goes away until the last update check when user dismisses the notice.

**Verification**

Using this branch on any test site and changing plugin versions in readme and patreon.php (file header) to older versions than PATREON_WORDPRESS_VERSION in patreon.php will make the notice appear in the next plugin version check. Because this check is done via a WP cron, it may take long time so using "Force plugin updates check" plugin and manually forcing a plugin check would work.

**Does this need tests**

Manual test done, works. No unit test is written for this feature yet.