### PR TITLE
Move v1 calls to v2

### DIFF
--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -19,7 +19,7 @@ class Patreon_API {
 
 		// We construct the old return from the new returns by combining /me and pledge details
 
-		$api_return = $this->__get_json( "identity?include=memberships&fields[user]=email,first_name,full_name,image_url,last_name,thumb_url,url,vanity,is_email_verified&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start",true );
+		$api_return = $this->__get_json( "identity?include=memberships&fields[user]=email,first_name,full_name,image_url,last_name,thumb_url,url,vanity,is_email_verified&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start", true );
 		
 		$creator_id = get_option( 'patreon-creator-id', false );
 		

--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -15,49 +15,41 @@ class Patreon_API {
 	
 	public function fetch_user( $v2 = false ) {
 
-		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		// Only uses v2 starting from this version!
+
+		// We construct the old return from the new returns by combining /me and pledge details
+
+		$api_return = $this->__get_json( "identity?include=memberships&fields[user]=email,first_name,full_name,image_url,last_name,thumb_url,url,vanity,is_email_verified&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start",true );
 		
-			// We construct the old return from the new returns by combining /me and pledge details
-
-			$api_return = $this->__get_json( "me?include=memberships&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start" );
-			
-			$creator_id = get_option( 'patreon-creator-id', false );
-			
-			if ( isset( $api_return['included'][0] ) AND is_array( $api_return['included'][0] ) ) {
-				
-				$api_return['included'][0]["relationships"]["creator"]["data"]["id"] = $creator_id;
-				$api_return['included'][0]['type']                                   = 'pledge';
-				$api_return['included'][0]['attributes']['amount_cents']             = $api_return['included'][0]['attributes']['currently_entitled_amount_cents'];
-				$api_return['included'][0]['attributes']['created_at']               = $api_return['included'][0]['attributes']['pledge_relationship_start'];
-				
-			}
-			if ( $api_return['included'][0]['attributes']['last_charge_status'] != 'Paid' ) {
-				
-				$api_return['included'][0]['attributes']['declined_since'] = $api_return['included'][0]['attributes']['last_charge_date'];
-				
-			}
-
-			return $api_return;
-			
-		}		
-
-		return $this->__get_json("current_user");
+		$creator_id = get_option( 'patreon-creator-id', false );
 		
+		if ( isset( $api_return['included'][0] ) AND is_array( $api_return['included'][0] ) ) {
+			
+			$api_return['included'][0]["relationships"]["creator"]["data"]["id"] = $creator_id;
+			$api_return['included'][0]['type']                                   = 'pledge';
+			$api_return['included'][0]['attributes']['amount_cents']             = $api_return['included'][0]['attributes']['currently_entitled_amount_cents'];
+			$api_return['included'][0]['attributes']['created_at']               = $api_return['included'][0]['attributes']['pledge_relationship_start'];
+			
+		}
+		
+		if ( $api_return['included'][0]['attributes']['last_charge_status'] != 'Paid' ) {
+			$api_return['included'][0]['attributes']['declined_since'] = $api_return['included'][0]['attributes']['last_charge_date'];
+		}
+			
+		return $api_return;
 	}
 	
-	public function fetch_campaign_and_patrons ($v2 = false ) {
+	public function fetch_campaign_and_patrons($v2 = false ) {
 	
-		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2' , false ) == 'yes' ) {
-			
+		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period. Currently we are using v1 for creator/campaign related calls
+		
+		if ( $v2 ) {		
 			// New call to campaigns doesnt return pledges in v2 api - currently this function is not used anywhere in plugin. If 3rd party devs are using it, it will need to be looked into
 			
 			// Requires having gotten permission for pledge scope during auth if used for a normal user instead of the creator
 
-			return $this->__get_json( "campaigns?include=rewards,creator,goals,pledges" );
-			
-		}		
+			return $this->__get_json( "campaigns" );
+		}	
 
 		return $this->__get_json( "current_user/campaigns?include=rewards,creator,goals,pledges" );
 		
@@ -65,18 +57,18 @@ class Patreon_API {
 		
 	public function fetch_creator_info( $v2 = false ) {
 	
-		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period. Currently we are using v1 for creator/campaign related calls
+		
+		if ( $v2 ) {
 			
 			// New call to campaigns doesnt return pledges in v2 api - currently this function is not used anywhere in plugin. If 3rd party devs are using it, it will need to be looked into
 			
-			$api_return                      = $this->__get_json( "campaigns?include=rewards,creator,goals" );
+			$api_return                      = $this->__get_json( "identity" );
 			$api_return['included'][0]['id'] = $api_return['data'][0]['id'];
 
 			return $api_return;
-			
-		}		
-
+		}
+	
 		return $this->__get_json( "current_user/campaigns?include=creator" );
 		
 	}
@@ -84,7 +76,8 @@ class Patreon_API {
 	public function fetch_campaign( $v2 = false ) {
 		
 		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		
+		if ( $v2 ) {
 			return $this->__get_json( "campaigns?include=rewards,creator,goals" );
 		}
 
@@ -96,10 +89,10 @@ class Patreon_API {
 
 		$api_endpoint = "https://api.patreon.com/oauth2/api/" . $suffix;
 
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		if ( $v2 ) {
 			$api_endpoint = "https://www.patreon.com/api/oauth2/v2/" . $suffix;	
 		}
-	
+		
 		$headers = array(
 			'Authorization' => 'Bearer ' . $this->access_token,
 			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
@@ -112,7 +105,7 @@ class Patreon_API {
 
 		$response = wp_remote_request( $api_endpoint, $api_request );
 		$result   = $response;
-		
+
 		if ( is_wp_error( $response ) ) {
 			
 			$result                    = array( 'error' => $response->get_error_message() );
@@ -124,9 +117,5 @@ class Patreon_API {
 		return json_decode( $response['body'], true );
 		
 	}
-
-	public function check_api_v2() {
-		// Transitional function - checks if api v2 can be contacted with existing credentials and returns the result
-		return $this->__get_json( "campaigns?include=rewards,creator,goals", true );
-	}
+	
 }

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -569,7 +569,11 @@ class Patreon_Frontend {
 		$redirect_uri           = site_url() . '/patreon-authorization/';
 		$v2_params = '&scope=' . 'identity+' . urlencode( 'identity[email]' );
 		
-		$href                  = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' . $client_id . $v2_params . '&redirect_uri=' . urlencode($redirect_uri) .  '&state=' . urlencode( base64_encode( serialize( $state ) ) );
+		$href                  = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' 
+		. $client_id . $v2_params 
+		. '&redirect_uri=' . urlencode($redirect_uri) 
+		. '&state=' . urlencode( base64_encode( serialize( $state ) ) );
+		
 		$href                  = apply_filters( 'ptrn/login_link', $href );
 		$filterable_utm_params = 'utm_term=&utm_content=login_button';
 		$filterable_utm_params = apply_filters( 'ptrn/utm_params_for_login_link', $filterable_utm_params );

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -63,47 +63,43 @@ class Patron_Metabox {
 
 		<?php
 		
-		if ( get_option( 'patreon-can-use-api-v2',false ) == 'yes' ) {
+		$label    = 'Active patrons only (optional) - if on, only patrons active at and before this post\'s publishing date will be able to see this content )';
+		$readonly = '';
+		
+		if ( !get_option( 'patreon-creator-id', false ) ) {
 			
-			$label    = 'Active patrons only (optional) - if on, only patrons active at and before this post\'s publishing date will be able to see this content )';
-			$readonly = '';
-			
-			if ( !get_option( 'patreon-creator-id', false ) ) {
-				
-				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin" ).'">here</a>';
-				$readonly = " readonly";
-				
-			}
-
-			?>
-			<p>
-				<label for="patreon-active-patrons-only"><?php _e( $label, '1' ); ?></label>
-				<br><br>
-				<input type="checkbox" name="patreon-active-patrons-only" value="1" <?php checked( get_post_meta( $object->ID, 'patreon-active-patrons-only', true ),true,true ); ?> <?php echo $readonly ?> /> Yes
-			</p>
-
-			<?php
-			
-			$label    = 'Total patronage (optional) - any patron above total lifetime patronage $ value entered below can see this content';
-			$readonly = '';
-			
-			if ( !get_option( 'patreon-creator-id', false ) ) {
-				
-				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url("?page=patreon-plugin").'">here</a>';
-				$readonly = " readonly";
-				
-			}
-
-			?>
-			<p>
-				<label for="patreon-total-patronage-level"><?php _e( $label, '1' ); ?></label>
-				<br><br>
-				<strong>&#36; </strong><input type="text" id="patreon-total-patronage-level" name="patreon-total-patronage-level" value="<?php echo get_post_meta( $object->ID, 'patreon-total-patronage-level', true ); ?>" <?php echo $readonly ?>>
-			</p>
-
-			<?php
+			$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin" ).'">here</a>';
+			$readonly = " readonly";
 			
 		}
+
+		?>
+		<p>
+			<label for="patreon-active-patrons-only"><?php _e( $label, '1' ); ?></label>
+			<br><br>
+			<input type="checkbox" name="patreon-active-patrons-only" value="1" <?php checked( get_post_meta( $object->ID, 'patreon-active-patrons-only', true ),true,true ); ?> <?php echo $readonly ?> /> Yes
+		</p>
+
+		<?php
+		
+		$label    = 'Total patronage (optional) - any patron above total lifetime patronage $ value entered below can see this content';
+		$readonly = '';
+		
+		if ( !get_option( 'patreon-creator-id', false ) ) {
+			
+			$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url("?page=patreon-plugin").'">here</a>';
+			$readonly = " readonly";
+			
+		}
+
+		?>
+		<p>
+			<label for="patreon-total-patronage-level"><?php _e( $label, '1' ); ?></label>
+			<br><br>
+			<strong>&#36; </strong><input type="text" id="patreon-total-patronage-level" name="patreon-total-patronage-level" value="<?php echo get_post_meta( $object->ID, 'patreon-total-patronage-level', true ); ?>" <?php echo $readonly ?>>
+		</p>
+
+		<?php
 		
 	}
 

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -314,7 +314,7 @@ class Patreon_Routing {
 			
 		}
 		if ( strpos( $_SERVER['REQUEST_URI'], '/patreon-authorization/' ) !== false ) {
-	
+
 			if( array_key_exists( 'code', $wp->query_vars ) ) {
 				
 				// Get state vars if they exist
@@ -354,6 +354,7 @@ class Patreon_Routing {
 				}
 
 				$tokens = $oauth_client->get_tokens( $wp->query_vars['code'], site_url() . '/patreon-authorization/' );
+
 
 				if( array_key_exists( 'error', $tokens ) ) {
 

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -44,7 +44,6 @@ class Patreon_Wordpress {
 
 		add_action( 'wp_head', array( $this, 'updatePatreonUser' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorID' ) );
-		add_action( 'init', array( $this, 'checkv2APIAccess' ) );
 		add_action( 'init', array( $this, 'checkPatreonCampaignID' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorURL' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorName' ) );
@@ -145,7 +144,7 @@ class Patreon_Wordpress {
 
 	}
 	public static function checkPatreonCreatorID() {
-	
+		
 		// Check if creator id doesnt exist. Account for the case in which creator id was saved as empty by the Creator
 
 		if ( !get_option( 'patreon-creator-id', false ) OR get_option( 'patreon-creator-id', false )== '' ) {
@@ -166,39 +165,6 @@ class Patreon_Wordpress {
 				// Creator id acquired. Update.
 				update_option( 'patreon-creator-id', $creator_id );
 			}
-			
-		}
-		
-	}
-	public static function checkv2APIAccess() {
-		
-		// Check if we can contact API v2 with the creator access token we have. Account for the case in which creator id was saved as empty by the Creator
-		
-		if ( !get_option('patreon-can-use-api-v2', false ) ) {	
-		
-			// Making sure access credentials are there to avoid fruitlessly contacting the api:
-			
-			if ( get_option( 'patreon-client-id', false ) 
-				&& get_option( 'patreon-client-secret', false ) 
-				&& get_option( 'patreon-creators-access-token', false )
-			) {
-				
-				// Credentials are in. Go.
-				
-				$api_client = new Patreon_API( get_option( 'patreon-creators-access-token' , false ) );
-
-				$api_response = $api_client->check_api_v2();
-		
-			}
-			
-			$can_use = 'no';
-			
-			if ( $api_response['data'][0]['type']=='campaign' ) {
-				// Got a valid result. Update.
-				$can_use = 'yes';
-			}
-			
-			update_option( 'patreon-can-use-api-v2', $can_use );
 			
 		}
 		


### PR DESCRIPTION
**Problem**

Make plugin utilize parts of new functionality that comes with API v2. 

**Solution***

Translated the fetch_user call that is used by pledge/patronage checking functions to v2. Flow and login link generators updated to request proper v2 scopes when sending users to flow or login. fetch_user call now asks for proper includes to the v2 endpoint. Metaboxes for the post locking interface updated to always show v2 functionality that comes with total historical pledge and pledge relationship start. Locking logic updated to always check for presence of these locking options. Now dormant v2 api access checking function and its hook removed. 

![new-v2-features](https://user-images.githubusercontent.com/13155428/45241515-12f77280-b2ed-11e8-8e57-2af3c208055b.png)

The above user interface is to be updated in its own branch after its review yet, its provisional.

**Verification**

Tested on development site with actual valid patron, all functions work. Default $ level locking mechanism works. Pledge relationship start date checking based on post's post date works. Total historical pledge check to override all checks works.

Tests can be done by installing this branch of the plugin on any WP installation with valid v1 client details.

**Does this need tests**

Manual tests done, they work. No unit test is written for this feature yet.