### PR TITLE
Add compatibility class

### DIFF
--- a/classes/patreon_compatibility.php
+++ b/classes/patreon_compatibility.php
@@ -1,0 +1,31 @@
+<?php
+
+// If this file is called directly, abort.
+if ( !defined( 'WPINC' ) ) {
+	die;
+}
+
+class Patreon_Compatibility {
+
+	function __construct() {
+		
+		add_action( 'init', array( $this, 'set_cache_exceptions' ) );
+		
+	}
+
+	public function set_cache_exceptions() {
+		// Sets exceptions for caching to prevent important pages from being cached
+		
+		// Check for flow or authorization pages which shouldnt be cached
+		if ( strpos( $_SERVER['REQUEST_URI'],'/patreon-flow/' ) !== false 
+			OR strpos( $_SERVER['REQUEST_URI'], '/patreon-authorization/' ) !== false
+		) {
+			
+			// We are in either of these pages. Set do not cache page constant
+			define( 'DONOTCACHEPAGE', true );
+			// This constant is used in many plugins - wp super cache, w3 total cache, woocommerce etc and it should disable caching for this page
+		
+		}
+	}
+	
+}

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -314,6 +314,12 @@ class Patreon_Routing {
 			
 		}
 		if ( strpos( $_SERVER['REQUEST_URI'], '/patreon-authorization/' ) !== false ) {
+			
+			// First slap the noindex header so search engines wont index this page:
+			header( 'X-Robots-Tag: noindex, nofollow' );
+			 
+			// Make sure browsers dont cache this
+			header( 'cache-control: no-cache, must-revalidate, max-age=0' );			
 	
 			if( array_key_exists( 'code', $wp->query_vars ) ) {
 				

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -13,6 +13,7 @@ class Patreon_Wordpress {
 	private static $Patreon_Protect;
 	private static $Patreon_Options;
 	private static $Patron_Metabox;
+	private static $Patron_Compatibility;
 	private static $Patreon_User_Profiles;
 	public static $current_user_pledge_amount = -1;
 	public static $current_user_patronage_declined = -1;
@@ -34,6 +35,7 @@ class Patreon_Wordpress {
 		include 'patreon_metabox.php';
 		include 'patreon_user_profiles.php';
 		include 'patreon_protect.php';
+		include 'patreon_compatibility.php';
 
 		self::$Patreon_Routing       = new Patreon_Routing;
 		self::$Patreon_Frontend      = new Patreon_Frontend;
@@ -41,6 +43,7 @@ class Patreon_Wordpress {
 		self::$Patron_Metabox        = new Patron_Metabox;
 		self::$Patreon_User_Profiles = new Patreon_User_Profiles;
 		self::$Patreon_Protect       = new Patreon_Protect;
+		self::$Patron_Compatibility  = new Patreon_Compatibility;
 
 		add_action( 'wp_head', array( $this, 'updatePatreonUser' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorID' ) );


### PR DESCRIPTION
**Problem**

Caching plugins and host cache setups cache important login/authorization pages, causing the users not being able to log in or unlock posts. Compatibility code to tell plugins does not exist.

**Solution***

Compatibility code to tell caching plugins and systems to not cache important pages like patreon-authorization and patreon-flow added. A new class in, patreon_compatibility.php holds this code and runs it at init, telling caching plugins to ignore the relevant pages when doing caching. Uses widely used DONOTCACHEPAGE define.

New Patreon_Compatibility class will also allow other compatibility code and will keep compatibility code away from core classes.

***Verification***

Tested with WP Super Cache and confirmed to kick in when patreon-authorization or patreon-flow urls are requested. 

***Does this need tests***

DONOTCACHEPAGE page define is a widely accepted define, but it is up to plugins and host caching setups to respect it. Its tested to kick in at the necessary urls, checks out. If any individual caching plugin is reported to be caching these pages in future, they would need to be tested individually.