### PR TITLE
Cache updatepatreonuser checks

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -98,4 +98,37 @@ jQuery( function( $ ) {
 		});
 	});	
 	
+	jQuery(document).on( 'click', '.patreon-wordpress-admin-toggle', function(e) {
+		
+		e.preventDefault();
+		
+		var toggle_id = jQuery( this ).attr( 'toggle' );
+		var toggle_target = document.getElementById( toggle_id );
+
+		jQuery( toggle_target ).slideToggle();
+		
+		if( jQuery( this ).attr( 'togglestatus' ) == 'off' ) {
+			
+			jQuery( this ).html( jQuery( this ).attr( 'ontext' ) );
+			jQuery( this ).attr( 'togglestatus', 'on' );
+			
+		}
+		else if( jQuery( this ).attr( 'togglestatus' ) == 'on' ) {
+			
+			jQuery( this ).html( jQuery( this ).attr( 'offtext' ) );
+			jQuery( this ).attr( 'togglestatus', 'off' );
+			
+		}
+				
+		jQuery.ajax({
+			url: ajaxurl,
+			type:"POST",
+			dataType : 'html',
+			data: {
+				action: 'patreon_wordpress_toggle_option',
+				toggle_id: toggle_id,
+			}
+		});		
+		
+	});
 });

--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -19,7 +19,7 @@ class Patreon_API {
 
 		// We construct the old return from the new returns by combining /me and pledge details
 
-		$api_return = $this->__get_json( "identity?include=memberships&fields[user]=email,first_name,full_name,image_url,last_name,thumb_url,url,vanity,is_email_verified&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start",true );
+		$api_return = $this->__get_json( "identity?include=memberships&fields[user]=email,first_name,full_name,image_url,last_name,thumb_url,url,vanity,is_email_verified&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start", true );
 		
 		$creator_id = get_option( 'patreon-creator-id', false );
 		

--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -15,49 +15,41 @@ class Patreon_API {
 	
 	public function fetch_user( $v2 = false ) {
 
-		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		// Only uses v2 starting from this version!
+
+		// We construct the old return from the new returns by combining /me and pledge details
+
+		$api_return = $this->__get_json( "identity?include=memberships&fields[user]=email,first_name,full_name,image_url,last_name,thumb_url,url,vanity,is_email_verified&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start",true );
 		
-			// We construct the old return from the new returns by combining /me and pledge details
-
-			$api_return = $this->__get_json( "me?include=memberships&fields[member]=currently_entitled_amount_cents,lifetime_support_cents,last_charge_status,patron_status,last_charge_date,pledge_relationship_start" );
-			
-			$creator_id = get_option( 'patreon-creator-id', false );
-			
-			if ( isset( $api_return['included'][0] ) AND is_array( $api_return['included'][0] ) ) {
-				
-				$api_return['included'][0]["relationships"]["creator"]["data"]["id"] = $creator_id;
-				$api_return['included'][0]['type']                                   = 'pledge';
-				$api_return['included'][0]['attributes']['amount_cents']             = $api_return['included'][0]['attributes']['currently_entitled_amount_cents'];
-				$api_return['included'][0]['attributes']['created_at']               = $api_return['included'][0]['attributes']['pledge_relationship_start'];
-				
-			}
-			if ( $api_return['included'][0]['attributes']['last_charge_status'] != 'Paid' ) {
-				
-				$api_return['included'][0]['attributes']['declined_since'] = $api_return['included'][0]['attributes']['last_charge_date'];
-				
-			}
-
-			return $api_return;
-			
-		}		
-
-		return $this->__get_json("current_user");
+		$creator_id = get_option( 'patreon-creator-id', false );
 		
+		if ( isset( $api_return['included'][0] ) AND is_array( $api_return['included'][0] ) ) {
+			
+			$api_return['included'][0]["relationships"]["creator"]["data"]["id"] = $creator_id;
+			$api_return['included'][0]['type']                                   = 'pledge';
+			$api_return['included'][0]['attributes']['amount_cents']             = $api_return['included'][0]['attributes']['currently_entitled_amount_cents'];
+			$api_return['included'][0]['attributes']['created_at']               = $api_return['included'][0]['attributes']['pledge_relationship_start'];
+			
+		}
+		
+		if ( $api_return['included'][0]['attributes']['last_charge_status'] != 'Paid' ) {
+			$api_return['included'][0]['attributes']['declined_since'] = $api_return['included'][0]['attributes']['last_charge_date'];
+		}
+			
+		return $api_return;
 	}
 	
-	public function fetch_campaign_and_patrons ($v2 = false ) {
+	public function fetch_campaign_and_patrons($v2 = false ) {
 	
-		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2' , false ) == 'yes' ) {
-			
+		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period. Currently we are using v1 for creator/campaign related calls
+		
+		if ( $v2 ) {		
 			// New call to campaigns doesnt return pledges in v2 api - currently this function is not used anywhere in plugin. If 3rd party devs are using it, it will need to be looked into
 			
 			// Requires having gotten permission for pledge scope during auth if used for a normal user instead of the creator
 
-			return $this->__get_json( "campaigns?include=rewards,creator,goals,pledges" );
-			
-		}		
+			return $this->__get_json( "campaigns" );
+		}	
 
 		return $this->__get_json( "current_user/campaigns?include=rewards,creator,goals,pledges" );
 		
@@ -65,18 +57,18 @@ class Patreon_API {
 		
 	public function fetch_creator_info( $v2 = false ) {
 	
-		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period. Currently we are using v1 for creator/campaign related calls
+		
+		if ( $v2 ) {
 			
 			// New call to campaigns doesnt return pledges in v2 api - currently this function is not used anywhere in plugin. If 3rd party devs are using it, it will need to be looked into
 			
-			$api_return                      = $this->__get_json( "campaigns?include=rewards,creator,goals" );
+			$api_return                      = $this->__get_json( "identity" );
 			$api_return['included'][0]['id'] = $api_return['data'][0]['id'];
 
 			return $api_return;
-			
-		}		
-
+		}
+	
 		return $this->__get_json( "current_user/campaigns?include=creator" );
 		
 	}
@@ -84,7 +76,8 @@ class Patreon_API {
 	public function fetch_campaign( $v2 = false ) {
 		
 		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		
+		if ( $v2 ) {
 			return $this->__get_json( "campaigns?include=rewards,creator,goals" );
 		}
 
@@ -96,10 +89,10 @@ class Patreon_API {
 
 		$api_endpoint = "https://api.patreon.com/oauth2/api/" . $suffix;
 
-		if ( $v2 OR get_option( 'patreon-can-use-api-v2', false ) == 'yes' ) {
+		if ( $v2 ) {
 			$api_endpoint = "https://www.patreon.com/api/oauth2/v2/" . $suffix;	
 		}
-	
+		
 		$headers = array(
 			'Authorization' => 'Bearer ' . $this->access_token,
 			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
@@ -112,7 +105,7 @@ class Patreon_API {
 
 		$response = wp_remote_request( $api_endpoint, $api_request );
 		$result   = $response;
-		
+
 		if ( is_wp_error( $response ) ) {
 			
 			$result                    = array( 'error' => $response->get_error_message() );
@@ -124,9 +117,5 @@ class Patreon_API {
 		return json_decode( $response['body'], true );
 		
 	}
-
-	public function check_api_v2() {
-		// Transitional function - checks if api v2 can be contacted with existing credentials and returns the result
-		return $this->__get_json( "campaigns?include=rewards,creator,goals", true );
-	}
+	
 }

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -569,7 +569,11 @@ class Patreon_Frontend {
 		$redirect_uri           = site_url() . '/patreon-authorization/';
 		$v2_params = '&scope=' . 'identity+' . urlencode( 'identity[email]' );
 		
-		$href                  = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' . $client_id . $v2_params . '&redirect_uri=' . urlencode($redirect_uri) .  '&state=' . urlencode( base64_encode( serialize( $state ) ) );
+		$href                  = 'https://www.patreon.com/oauth2/authorize?response_type=code&client_id=' 
+		. $client_id . $v2_params 
+		. '&redirect_uri=' . urlencode($redirect_uri) 
+		. '&state=' . urlencode( base64_encode( serialize( $state ) ) );
+		
 		$href                  = apply_filters( 'ptrn/login_link', $href );
 		$filterable_utm_params = 'utm_term=&utm_content=login_button';
 		$filterable_utm_params = apply_filters( 'ptrn/utm_params_for_login_link', $filterable_utm_params );

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -750,7 +750,9 @@ class Patreon_Frontend {
 		
 	}
 	public static function protectContentFromUsers( $content ) {
-
+		
+		// Function is being fed content as the input var. Meaning we have to be inside the_content filter
+		
 		global $post;
 		
 		// Just bail out if this is not the main query for content
@@ -758,128 +760,39 @@ class Patreon_Frontend {
 			return $content;
 		}
 		
-		$post_types = get_post_types( array( 'public' => true ), 'names' );
-	
-		if ( in_array( get_post_type(), $post_types ) ) {
-			
-			$exclude = array(
-			);
-			
-			// Enables 3rd party plugins to modify the post types excluded from locking
-			$exclude = apply_filters( 'ptrn/filter_excluded_posts', $exclude );
+		// Now send the post id to locking decision function 
+		
+		$lock_or_not = Patreon_Wordpress::lock_or_not($post->ID);
+		
+		// An array with args should be returned
 
-			if ( in_array( get_post_type(), $exclude ) ) {
-				return $content;
-			}
-			
-			// First check if entire site is locked, get the level for locking.
-			
-			$patreon_level = get_option( 'patreon-lock-entire-site', false );
-			
-			// Check if specific level is given for this post:
-			
-			$post_level = get_post_meta( $post->ID, 'patreon-level', true );
-			
-			// get post meta returns empty if no value is found. If so, set the value to 0.
-			
-			if ( $post_level == '' ) {
-				$post_level = 0;				
-			}
+		$hide_content = $lock_or_not['lock'];
 
-			// Check if both post level and site lock level are set to 0 or nonexistent. If so return normal content.
+		if( $hide_content ) {
 			
-			if ( $post_level == 0 
-				&& ( !$patreon_level
-					|| $patreon_level == 0 )
-			) {
+			// protect content from user
+			
+			// Get client id
+			
+			$client_id = get_option( 'patreon-client-id', false );
+			
+			// // If client id exists. Do the banner. If not, no point in protecting since we wont be able to send people to patronage. If so dont modify normal content.
+			
+			if( $client_id ) {
+				
+				$content = self::displayPatreonCampaignBanner( $patreon_level );
+				$content = apply_filters( 'ptrn/post_content', $content, $patreon_level, $user_patronage );
 				return $content;
-			}
-			
-			// If we are at this point, then this post is protected. 
-			
-			// Below define can be defined in any plugin to bypass core locking function and use a custom one from plugin
-			// It is independent of the plugin load order since it checks if it is defined.
-			// It can be defined by any plugin until right before the_content filter is run.
-	
-			if ( apply_filters( 'ptrn/bypass_filtering', defined( 'PATREON_BYPASS_FILTERING' ) ) ) {
-                return $content;
-            }
-			 
-			if ( current_user_can( 'manage_options' ) ) {
-				// Here we need to put a notification to admins so they will know they can see the content because they are admin_login_with_patreon_disabled
-				return $content . self::MakeAdminPostFooter( $patreon_level );
-			}	
-				
-			// Passed checks. If post level is not 0, override patreon level and hence site locking value with post's. This will allow Creators to lock entire site and then set a different value for individual posts for access. Ie, site locking is $5, but one particular post can be $10, and it will require $10 to see. 
-			
-			if ( $post_level !=0 ) {
-				$patreon_level = $post_level;
-			}
-			 
-			$user                           = wp_get_current_user();
-			$user_pledge_relationship_start = Patreon_Wordpress::get_user_pledge_relationship_start();
-			$user_patronage                 = Patreon_Wordpress::getUserPatronage();
-			$user_lifetime_patronage        = Patreon_Wordpress::get_user_lifetime_patronage();
-			$declined                       = Patreon_Wordpress::checkDeclinedPatronage($user);
-			
-			
-			// Check if post was set for active patrons only
-			$patreon_active_patrons_only = get_post_meta( $post->ID, 'patreon-active-patrons-only', true );
-			
-			// Check if specific total patronage is given for this post:
-			$post_total_patronage_level = get_post_meta( $post->ID, 'patreon-total-patronage-level', true );
-		
-		
-			$hide_content = true;
-		
-			if ( !( $user_patronage == false
-				|| $user_patronage < ( $patreon_level * 100 )
-				|| $declined ) ) {
-					
-				$hide_content = false;
-				
-				// Seems valid patron. Lets see if active patron option was set and the user fulfills it
-				
-				if ( $patreon_active_patrons_only == '1'
-				AND $user_pledge_relationship_start >= strtotime( get_the_date( '', $post->ID ) ) ) {
-					$hide_content = true;
-				}
-				
-			}			
-		
-			if ( $post_total_patronage_level !='' AND $post_total_patronage_level > 0) {
-				
-				// Total patronage set if user has lifetime patronage over this level, we let him see the content
-				if( $user_lifetime_patronage >= $post_total_patronage_level * 100 ) {
-					$hide_content = false;
-				}
 				
 			}
-				
-			
-			if( $hide_content ) {
-				
-				// protect content from user
-				
-				// Get client id
-				
-				$client_id = get_option( 'patreon-client-id', false );
-				
-				// // If client id exists. Do the banner. If not, no point in protecting since we wont be able to send people to patronage. If so dont modify normal content.
-				
-				if( $client_id ) {
-					
-					$content = self::displayPatreonCampaignBanner( $patreon_level );
-					$content = apply_filters( 'ptrn/post_content', $content, $patreon_level, $user_patronage );
-					return $content;
-					
-				}
-			}
-			
-			// If we are here, it means post is protected, user is patron, patronage is valid. Slap the post footer:
-			return $content .self::MakeValidPatronFooter($patreon_level, $user_patronage);
 		}
-				
+			
+		// If we are here, it means post is protected, user is patron, patronage is valid. Slap the post footer:
+		return $content . self::MakeValidPatronFooter($patreon_level, $user_patronage);		
+						
+		return $content . self::MakeAdminPostFooter( $patreon_level );
+		
+		return $content . self::MakeValidPatronFooter($patreon_level, $user_patronage);
 		// Return content in all other cases
 		return $content;
 		

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -60,45 +60,72 @@ class Patron_Metabox {
 			<br><br>
 			<strong>&#36; </strong><input type="text" id="patreon-level" name="patreon-level" value="<?php echo get_post_meta( $object->ID, 'patreon-level', true ); ?>" <?php echo $readonly ?>>
 		</p>
-
-		<?php
 		
-		$label    = 'Active patrons only (optional) - if on, only patrons active at and before this post\'s publishing date will be able to see this content )';
-		$readonly = '';
+		<?php 
+			
+			$advanced_post_options_toggle_status = get_option( 'patreon-wordpress-advanced-options-toggle', false );
+						
+			$advanced_post_options_toggle_status_display = 'style=" display: block;" ';
+			
+			if( !$advanced_post_options_toggle_status OR $advanced_post_options_toggle_status == 'off' ) {
+				$advanced_post_options_toggle_status_display = 'style=" display: none;" ';
+			}
+		?> 		
 		
-		if ( !get_option( 'patreon-creator-id', false ) ) {
+		<div <?php echo $advanced_post_options_toggle_status_display ?>id="patreon-wordpress-advanced-options-toggle">
+		
+			<?php
 			
-			$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin" ).'">here</a>';
-			$readonly = " readonly";
+			$label    = 'Active patrons only (optional) - if on, only patrons active at and before this post\'s publishing date will be able to see this content )';
+			$readonly = '';
 			
-		}
+			if ( !get_option( 'patreon-creator-id', false ) ) {
+				
+				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin" ).'">here</a>';
+				$readonly = " readonly";
+				
+			}
 
+			?>
+			<p>
+				<label for="patreon-active-patrons-only"><?php _e( $label, '1' ); ?></label>
+				<br><br>
+				<input type="checkbox" name="patreon-active-patrons-only" value="1" <?php checked( get_post_meta( $object->ID, 'patreon-active-patrons-only', true ),true,true ); ?> <?php echo $readonly ?> /> Yes
+			</p>
+
+			<?php
+			
+			$label    = 'Total patronage (optional) - any patron above total lifetime patronage $ value entered below can see this content';
+			$readonly = '';
+			
+			if ( !get_option( 'patreon-creator-id', false ) ) {
+				
+				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url("?page=patreon-plugin").'">here</a>';
+				$readonly = " readonly";
+				
+			}
+
+			?>
+			<p>
+				<label for="patreon-total-patronage-level"><?php _e( $label, '1' ); ?></label>
+				<br><br>
+				<strong>&#36; </strong><input type="text" id="patreon-total-patronage-level" name="patreon-total-patronage-level" value="<?php echo get_post_meta( $object->ID, 'patreon-total-patronage-level', true ); ?>" <?php echo $readonly ?>>
+			</p>
+		
+		</div>
+		<br />
+		
+		<?php 
+			
+			$advanced_post_options_toggle_text = 'Hide advanced';
+			
+			if( !$advanced_post_options_toggle_status OR $advanced_post_options_toggle_status == 'off' ) {
+				$advanced_post_options_toggle_text = 'Show advanced';
+			}
 		?>
-		<p>
-			<label for="patreon-active-patrons-only"><?php _e( $label, '1' ); ?></label>
-			<br><br>
-			<input type="checkbox" name="patreon-active-patrons-only" value="1" <?php checked( get_post_meta( $object->ID, 'patreon-active-patrons-only', true ),true,true ); ?> <?php echo $readonly ?> /> Yes
-		</p>
-
-		<?php
 		
-		$label    = 'Total patronage (optional) - any patron above total lifetime patronage $ value entered below can see this content';
-		$readonly = '';
+		<a href="" toggle="patreon-wordpress-advanced-options-toggle" togglestatus="<?php echo $advanced_post_options_toggle_status ?>" ontext="Hide advanced" offtext="Show advanced" class="patreon-wordpress-admin-toggle"><?php echo $advanced_post_options_toggle_text ?></a>
 		
-		if ( !get_option( 'patreon-creator-id', false ) ) {
-			
-			$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url("?page=patreon-plugin").'">here</a>';
-			$readonly = " readonly";
-			
-		}
-
-		?>
-		<p>
-			<label for="patreon-total-patronage-level"><?php _e( $label, '1' ); ?></label>
-			<br><br>
-			<strong>&#36; </strong><input type="text" id="patreon-total-patronage-level" name="patreon-total-patronage-level" value="<?php echo get_post_meta( $object->ID, 'patreon-total-patronage-level', true ); ?>" <?php echo $readonly ?>>
-		</p>
-
 		<?php
 		
 	}

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -63,47 +63,43 @@ class Patron_Metabox {
 
 		<?php
 		
-		if ( get_option( 'patreon-can-use-api-v2',false ) == 'yes' ) {
+		$label    = 'Active patrons only (optional) - if on, only patrons active at and before this post\'s publishing date will be able to see this content )';
+		$readonly = '';
+		
+		if ( !get_option( 'patreon-creator-id', false ) ) {
 			
-			$label    = 'Active patrons only (optional) - if on, only patrons active at and before this post\'s publishing date will be able to see this content )';
-			$readonly = '';
-			
-			if ( !get_option( 'patreon-creator-id', false ) ) {
-				
-				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin" ).'">here</a>';
-				$readonly = " readonly";
-				
-			}
-
-			?>
-			<p>
-				<label for="patreon-active-patrons-only"><?php _e( $label, '1' ); ?></label>
-				<br><br>
-				<input type="checkbox" name="patreon-active-patrons-only" value="1" <?php checked( get_post_meta( $object->ID, 'patreon-active-patrons-only', true ),true,true ); ?> <?php echo $readonly ?> /> Yes
-			</p>
-
-			<?php
-			
-			$label    = 'Total patronage (optional) - any patron above total lifetime patronage $ value entered below can see this content';
-			$readonly = '';
-			
-			if ( !get_option( 'patreon-creator-id', false ) ) {
-				
-				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url("?page=patreon-plugin").'">here</a>';
-				$readonly = " readonly";
-				
-			}
-
-			?>
-			<p>
-				<label for="patreon-total-patronage-level"><?php _e( $label, '1' ); ?></label>
-				<br><br>
-				<strong>&#36; </strong><input type="text" id="patreon-total-patronage-level" name="patreon-total-patronage-level" value="<?php echo get_post_meta( $object->ID, 'patreon-total-patronage-level', true ); ?>" <?php echo $readonly ?>>
-			</p>
-
-			<?php
+			$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin" ).'">here</a>';
+			$readonly = " readonly";
 			
 		}
+
+		?>
+		<p>
+			<label for="patreon-active-patrons-only"><?php _e( $label, '1' ); ?></label>
+			<br><br>
+			<input type="checkbox" name="patreon-active-patrons-only" value="1" <?php checked( get_post_meta( $object->ID, 'patreon-active-patrons-only', true ),true,true ); ?> <?php echo $readonly ?> /> Yes
+		</p>
+
+		<?php
+		
+		$label    = 'Total patronage (optional) - any patron above total lifetime patronage $ value entered below can see this content';
+		$readonly = '';
+		
+		if ( !get_option( 'patreon-creator-id', false ) ) {
+			
+			$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url("?page=patreon-plugin").'">here</a>';
+			$readonly = " readonly";
+			
+		}
+
+		?>
+		<p>
+			<label for="patreon-total-patronage-level"><?php _e( $label, '1' ); ?></label>
+			<br><br>
+			<strong>&#36; </strong><input type="text" id="patreon-total-patronage-level" name="patreon-total-patronage-level" value="<?php echo get_post_meta( $object->ID, 'patreon-total-patronage-level', true ); ?>" <?php echo $readonly ?>>
+		</p>
+
+		<?php
 		
 	}
 

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -41,6 +41,8 @@ class Patron_Metabox {
 	}
 
 	function patreon_plugin_meta_box( $object, $box ) { 
+	
+		$current_user = wp_get_current_user();
 			
 		$label    = 'Add a minimum Patreon contribution required to access this content.  (Makes entire post patron only)';
 		$readonly = '';
@@ -63,11 +65,11 @@ class Patron_Metabox {
 		
 		<?php 
 			
-			$advanced_post_options_toggle_status = get_option( 'patreon-wordpress-advanced-options-toggle', false );
+			$advanced_post_options_toggle_status = get_user_meta( $current_user->ID, 'patreon-wordpress-advanced-options-toggle', true );
 						
 			$advanced_post_options_toggle_status_display = 'style=" display: block;" ';
 			
-			if( !$advanced_post_options_toggle_status OR $advanced_post_options_toggle_status == 'off' ) {
+			if( $advanced_post_options_toggle_status == '' OR $advanced_post_options_toggle_status == 'off' ) {
 				$advanced_post_options_toggle_status_display = 'style=" display: none;" ';
 			}
 		?> 		
@@ -119,7 +121,7 @@ class Patron_Metabox {
 			
 			$advanced_post_options_toggle_text = 'Hide advanced';
 			
-			if( !$advanced_post_options_toggle_status OR $advanced_post_options_toggle_status == 'off' ) {
+			if( $advanced_post_options_toggle_status == '' OR $advanced_post_options_toggle_status == 'off' ) {
 				$advanced_post_options_toggle_text = 'Show advanced';
 			}
 		?>

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -314,7 +314,7 @@ class Patreon_Routing {
 			
 		}
 		if ( strpos( $_SERVER['REQUEST_URI'], '/patreon-authorization/' ) !== false ) {
-	
+
 			if( array_key_exists( 'code', $wp->query_vars ) ) {
 				
 				// Get state vars if they exist
@@ -354,6 +354,7 @@ class Patreon_Routing {
 				}
 
 				$tokens = $oauth_client->get_tokens( $wp->query_vars['code'], site_url() . '/patreon-authorization/' );
+
 
 				if( array_key_exists( 'error', $tokens ) ) {
 

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -337,19 +337,18 @@ class Patreon_Wordpress {
         return false;
 		
 	}
-	public static function getUserPatronage() {
+	public static function getUserPatronage( $user = false ) {
 		
 		if ( self::$current_user_pledge_amount != -1 ) {
 			return self::$current_user_pledge_amount;
 		}
 
-		if ( is_user_logged_in() == false ) {
-			return false;
-		}
-
-		$user = wp_get_current_user();
-		
+		// If user is not given, try to get the current user attribute ID will be 0 if there is no logged in user
 		if ( $user == false ) {
+			$user = wp_get_current_user();
+		}
+		// If still no user object, return false
+		if ( $user->ID == 0 ) {
 			return false;
 		}
 
@@ -710,8 +709,21 @@ class Patreon_Wordpress {
 			delete_option( 'patreon-wordpress-update-available');
 		}
 
-	}	
+	}
+	public static function map_language( $key ) {
+		// Maps string codes to language strings for use in interface text. It can be used as the base function to implement proper language translation features later.
+		
+		// Use a simple array for the time being
+		
+		$language_map = array(
+			'not_active_patron_at_post_date' => '',
+			'patron_fulfills_total_historical_pledge_requirement' => '',
+		);
+		
+		return $language_map[$key];
+	}		
 	public function toggle_option() {
+		
 		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
@@ -731,7 +743,7 @@ class Patreon_Wordpress {
 		update_user_meta( $current_user->ID, $option_to_toggle, $new_value );
 		
 	}
-	public static function lock_or_not($post_id = false) {
+	public static function lock_or_not( $post_id = false ) {
 		
 		// Just bail out if this is not the main query for content and no post id was given
 		if ( !is_main_query() AND !$post_id ) {
@@ -748,123 +760,123 @@ class Patreon_Wordpress {
 		else {
 			global $post;
 		}
-		
-		$post_types = get_post_types( array( 'public' => true ), 'names' );
-	
-		if ( in_array( get_post_type( $post->ID ), $post_types ) ) {
 			
-			$exclude = array(
+		$exclude = array(
+		);
+		
+		// Enables 3rd party plugins to modify the post types excluded from locking
+		$exclude = apply_filters( 'ptrn/filter_excluded_posts', $exclude );
+
+		if ( in_array( get_post_type( $post->ID ), $exclude ) ) {
+			return array(
+				'lock' => false,
+				'reason' => 'post_type_excluded_from_locking',
 			);
-			
-			// Enables 3rd party plugins to modify the post types excluded from locking
-			$exclude = apply_filters( 'ptrn/filter_excluded_posts', $exclude );
+		}
+		
+		// First check if entire site is locked, get the level for locking.
+		
+		$patreon_level = get_option( 'patreon-lock-entire-site', false );
+		
+		// Check if specific level is given for this post:
+		
+		$post_level = get_post_meta( $post->ID, 'patreon-level', true );
+		
+		// get post meta returns empty if no value is found. If so, set the value to 0.
+		
+		if ( $post_level == '' ) {
+			$post_level = 0;				
+		}
 
-			if ( in_array( get_post_type( $post->ID ), $exclude ) ) {
-				return array(
-					'lock' => false,
-					'reason' => 'post_id_excluded_from_locking',
-				);
-			}
-			
-			// First check if entire site is locked, get the level for locking.
-			
-			$patreon_level = get_option( 'patreon-lock-entire-site', false );
-			
-			// Check if specific level is given for this post:
-			
-			$post_level = get_post_meta( $post->ID, 'patreon-level', true );
-			
-			// get post meta returns empty if no value is found. If so, set the value to 0.
-			
-			if ( $post_level == '' ) {
-				$post_level = 0;				
-			}
+		// Check if both post level and site lock level are set to 0 or nonexistent. If so return normal content.
+		
+		if ( $post_level == 0 
+			&& ( !$patreon_level
+				|| $patreon_level == 0 )
+		) {
+			return array(
+				'lock' => false,
+				'reason' => 'post_is_public',
+			);
+		}
+		
+		// If we are at this point, then this post is protected. 
+		
+		// Below define can be defined in any plugin to bypass core locking function and use a custom one from plugin
+		// It is independent of the plugin load order since it checks if it is defined.
+		// It can be defined by any plugin until right before the_content filter is run.
 
-			// Check if both post level and site lock level are set to 0 or nonexistent. If so return normal content.
+		if ( apply_filters( 'ptrn/bypass_filtering', defined( 'PATREON_BYPASS_FILTERING' ) ) ) {
+			return array(
+				'lock'   => false,
+				'reason' => 'lock_bypassed_by_filter',
+			);
+		}
+		 
+		if ( current_user_can( 'manage_options' ) ) {
+			// Here we need to put a notification to admins so they will know they can see the content because they are admin_login_with_patreon_disabled
+			return array(
+				'lock' => false,
+				'reason' => 'show_to_admin_users',
+			);
+		}	
 			
-			if ( $post_level == 0 
-				&& ( !$patreon_level
-					|| $patreon_level == 0 )
-			) {
-				return array(
-					'lock' => false,
-					'reason' => 'post_is_not_locked',
-				);
-			}
-			
-			// If we are at this point, then this post is protected. 
-			
-			// Below define can be defined in any plugin to bypass core locking function and use a custom one from plugin
-			// It is independent of the plugin load order since it checks if it is defined.
-			// It can be defined by any plugin until right before the_content filter is run.
+		// Passed checks. If post level is not 0, override patreon level and hence site locking value with post's. This will allow Creators to lock entire site and then set a different value for individual posts for access. Ie, site locking is $5, but one particular post can be $10, and it will require $10 to see. 
+		
+		if ( $post_level !=0 ) {
+			$patreon_level = $post_level;
+		}
+		 
+		$user                           = wp_get_current_user();
+		$user_pledge_relationship_start = Patreon_Wordpress::get_user_pledge_relationship_start( $user );
+		$user_patronage                 = Patreon_Wordpress::getUserPatronage( $user );
+		$user_lifetime_patronage        = Patreon_Wordpress::get_user_lifetime_patronage( $user );
+		$declined                       = Patreon_Wordpress::checkDeclinedPatronage( $user );
+				
+		// Check if post was set for active patrons only
+		$patreon_active_patrons_only = get_post_meta( $post->ID, 'patreon-active-patrons-only', true );
+		
+		// Check if specific total patronage is given for this post:
+		$post_total_patronage_level = get_post_meta( $post->ID, 'patreon-total-patronage-level', true );
 	
-			if ( apply_filters( 'ptrn/bypass_filtering', defined( 'PATREON_BYPASS_FILTERING' ) ) ) {
-				return array(
-					'lock' => false,
-					'reason' => 'lock_bypassed_by_filter',
-				);
-            }
-			 
-			if ( current_user_can( 'manage_options' ) ) {
-				// Here we need to put a notification to admins so they will know they can see the content because they are admin_login_with_patreon_disabled
-				return array(
-					'lock' => false,
-					'reason' => 'show_to_admin_users',
-				);
-			}	
+	
+		$hide_content = true;
+		$reason = 'active_pledge_not_enough';
+	
+		if ( !( $user_patronage == false
+			|| $user_patronage < ( $patreon_level * 100 )
+			|| $declined ) ) {
 				
-			// Passed checks. If post level is not 0, override patreon level and hence site locking value with post's. This will allow Creators to lock entire site and then set a different value for individual posts for access. Ie, site locking is $5, but one particular post can be $10, and it will require $10 to see. 
+			$hide_content = false;
 			
-			if ( $post_level !=0 ) {
-				$patreon_level = $post_level;
+			// Seems valid patron. Lets see if active patron option was set and the user fulfills it
+			
+			if ( $patreon_active_patrons_only == '1'
+			AND $user_pledge_relationship_start >= strtotime( get_the_date( '', $post->ID ) ) ) {
+				$hide_content = true;
+				$reason = 'not_active_patron_at_post_date';
 			}
-			 
-			$user                           = wp_get_current_user();
-			$user_pledge_relationship_start = Patreon_Wordpress::get_user_pledge_relationship_start();
-			$user_patronage                 = Patreon_Wordpress::getUserPatronage();
-			$user_lifetime_patronage        = Patreon_Wordpress::get_user_lifetime_patronage();
-			$declined                       = Patreon_Wordpress::checkDeclinedPatronage( $user );
 			
+		}	
+	
+		if ( $post_total_patronage_level !='' AND $post_total_patronage_level > 0) {
 			
-			// Check if post was set for active patrons only
-			$patreon_active_patrons_only = get_post_meta( $post->ID, 'patreon-active-patrons-only', true );
-			
-			// Check if specific total patronage is given for this post:
-			$post_total_patronage_level = get_post_meta( $post->ID, 'patreon-total-patronage-level', true );
-		
-		
-			$hide_content = true;
-			$reason = 'active_pledge_not_enough';
-		
-			if ( !( $user_patronage == false
-				|| $user_patronage < ( $patreon_level * 100 )
-				|| $declined ) ) {
-					
+			// Total patronage set if user has lifetime patronage over this level, we let him see the content
+			if( $user_lifetime_patronage >= $post_total_patronage_level * 100 ) {
 				$hide_content = false;
-				
-				// Seems valid patron. Lets see if active patron option was set and the user fulfills it
-				
-				if ( $patreon_active_patrons_only == '1'
-				AND $user_pledge_relationship_start >= strtotime( get_the_date( '', $post->ID ) ) ) {
-					$hide_content = true;
-					$reason = 'not_active_patron_at_post_date';
-				}
-				
-			}	
-		
-			if ( $post_total_patronage_level !='' AND $post_total_patronage_level > 0) {
-				
-				// Total patronage set if user has lifetime patronage over this level, we let him see the content
-				if( $user_lifetime_patronage >= $post_total_patronage_level * 100 ) {
-					$hide_content = false;
-					$reason = 'patron_fulfills_total_historical_pledge_requirement';
-				}
-				
+				$reason = 'patron_fulfills_total_historical_pledge_requirement';
 			}
-				
 			
 		}
-	
+		
+		return array(
+			'lock'                        => $hide_content,
+			'reason'                      => $reason,
+			'patreon_level'               => $patreon_level,
+			'post_total_patronage_level'  => $post_total_patronage_level,
+			'patreon_active_patrons_only' => $patreon_active_patrons_only,
+		);
+		
 	}
 	
 }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -55,6 +55,7 @@ class Patreon_Wordpress {
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_section' ), 20 ) ;
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ) );
 		add_action( 'wp_ajax_patreon_wordpress_dismiss_admin_notice', array( $this, 'dismiss_admin_notice' ), 10, 1 );
+		add_action( 'wp_ajax_patreon_wordpress_toggle_option', array( $this, 'toggle_option' ), 10, 1 );
 
 	}
 	public static function getPatreonUser( $user ) {
@@ -711,6 +712,25 @@ class Patreon_Wordpress {
 			delete_option( 'patreon-wordpress-update-available');
 		}
 
+	}	
+	public function toggle_option() 
+	{
+		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
+			return;
+		}
+		
+		$option_to_toggle = $_REQUEST['toggle_id'];
+		
+		$current_value = get_option( $option_to_toggle, false );
+		
+		$new_value = 'off';
+		
+		if( !$current_value OR $current_value == 'off' ) {
+			$new_value = 'on';			
+		}
+		
+		update_option( $option_to_toggle, $new_value );
+		
 	}	
 	
 }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -44,7 +44,6 @@ class Patreon_Wordpress {
 
 		add_action( 'wp_head', array( $this, 'updatePatreonUser' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorID' ) );
-		add_action( 'init', array( $this, 'checkv2APIAccess' ) );
 		add_action( 'init', array( $this, 'checkPatreonCampaignID' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorURL' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorName' ) );
@@ -145,7 +144,7 @@ class Patreon_Wordpress {
 
 	}
 	public static function checkPatreonCreatorID() {
-	
+		
 		// Check if creator id doesnt exist. Account for the case in which creator id was saved as empty by the Creator
 
 		if ( !get_option( 'patreon-creator-id', false ) OR get_option( 'patreon-creator-id', false )== '' ) {
@@ -166,39 +165,6 @@ class Patreon_Wordpress {
 				// Creator id acquired. Update.
 				update_option( 'patreon-creator-id', $creator_id );
 			}
-			
-		}
-		
-	}
-	public static function checkv2APIAccess() {
-		
-		// Check if we can contact API v2 with the creator access token we have. Account for the case in which creator id was saved as empty by the Creator
-		
-		if ( !get_option('patreon-can-use-api-v2', false ) ) {	
-		
-			// Making sure access credentials are there to avoid fruitlessly contacting the api:
-			
-			if ( get_option( 'patreon-client-id', false ) 
-				&& get_option( 'patreon-client-secret', false ) 
-				&& get_option( 'patreon-creators-access-token', false )
-			) {
-				
-				// Credentials are in. Go.
-				
-				$api_client = new Patreon_API( get_option( 'patreon-creators-access-token' , false ) );
-
-				$api_response = $api_client->check_api_v2();
-		
-			}
-			
-			$can_use = 'no';
-			
-			if ( $api_response['data'][0]['type']=='campaign' ) {
-				// Got a valid result. Update.
-				$can_use = 'yes';
-			}
-			
-			update_option( 'patreon-can-use-api-v2', $can_use );
 			
 		}
 		

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -719,9 +719,11 @@ class Patreon_Wordpress {
 			return;
 		}
 		
+		$current_user = wp_get_current_user();
+		
 		$option_to_toggle = $_REQUEST['toggle_id'];
 		
-		$current_value = get_option( $option_to_toggle, false );
+		$current_value = get_user_meta( $current_user->ID, $option_to_toggle, true );
 		
 		$new_value = 'off';
 		
@@ -729,7 +731,7 @@ class Patreon_Wordpress {
 			$new_value = 'on';			
 		}
 		
-		update_option( $option_to_toggle, $new_value );
+		update_user_meta( $current_user->ID, $option_to_toggle, $new_value );
 		
 	}	
 	

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -683,8 +683,7 @@ class Patreon_Wordpress {
 		}
 		
 	}
-	public function check_for_update($plugin_check_data) 
-	{
+	public function check_for_update($plugin_check_data) {
 		global $wp_version, $plugin_version, $plugin_base;
 
 		if ( empty( $plugin_check_data->checked ) ) {
@@ -701,8 +700,7 @@ class Patreon_Wordpress {
 		return $plugin_check_data;
 		
 	}	
-	public function dismiss_admin_notice() 
-	{
+	public function dismiss_admin_notice() {
 		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
@@ -713,8 +711,7 @@ class Patreon_Wordpress {
 		}
 
 	}	
-	public function toggle_option() 
-	{
+	public function toggle_option() {
 		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
@@ -733,6 +730,141 @@ class Patreon_Wordpress {
 		
 		update_user_meta( $current_user->ID, $option_to_toggle, $new_value );
 		
-	}	
+	}
+	public static function lock_or_not($post_id = false) {
+		
+		// Just bail out if this is not the main query for content and no post id was given
+		if ( !is_main_query() AND !$post_id ) {
+			return array(
+				'lock' => false,
+				'reason' => 'no_post_id_no_main_query',
+			);
+		}
+		
+		// If post it received, get that post. If no post id received, try to get post from global
+		if ( $post_id ) {
+			$post = get_post( $post_id );
+		}
+		else {
+			global $post;
+		}
+		
+		$post_types = get_post_types( array( 'public' => true ), 'names' );
+	
+		if ( in_array( get_post_type( $post->ID ), $post_types ) ) {
+			
+			$exclude = array(
+			);
+			
+			// Enables 3rd party plugins to modify the post types excluded from locking
+			$exclude = apply_filters( 'ptrn/filter_excluded_posts', $exclude );
+
+			if ( in_array( get_post_type( $post->ID ), $exclude ) ) {
+				return array(
+					'lock' => false,
+					'reason' => 'post_id_excluded_from_locking',
+				);
+			}
+			
+			// First check if entire site is locked, get the level for locking.
+			
+			$patreon_level = get_option( 'patreon-lock-entire-site', false );
+			
+			// Check if specific level is given for this post:
+			
+			$post_level = get_post_meta( $post->ID, 'patreon-level', true );
+			
+			// get post meta returns empty if no value is found. If so, set the value to 0.
+			
+			if ( $post_level == '' ) {
+				$post_level = 0;				
+			}
+
+			// Check if both post level and site lock level are set to 0 or nonexistent. If so return normal content.
+			
+			if ( $post_level == 0 
+				&& ( !$patreon_level
+					|| $patreon_level == 0 )
+			) {
+				return array(
+					'lock' => false,
+					'reason' => 'post_is_not_locked',
+				);
+			}
+			
+			// If we are at this point, then this post is protected. 
+			
+			// Below define can be defined in any plugin to bypass core locking function and use a custom one from plugin
+			// It is independent of the plugin load order since it checks if it is defined.
+			// It can be defined by any plugin until right before the_content filter is run.
+	
+			if ( apply_filters( 'ptrn/bypass_filtering', defined( 'PATREON_BYPASS_FILTERING' ) ) ) {
+				return array(
+					'lock' => false,
+					'reason' => 'lock_bypassed_by_filter',
+				);
+            }
+			 
+			if ( current_user_can( 'manage_options' ) ) {
+				// Here we need to put a notification to admins so they will know they can see the content because they are admin_login_with_patreon_disabled
+				return array(
+					'lock' => false,
+					'reason' => 'show_to_admin_users',
+				);
+			}	
+				
+			// Passed checks. If post level is not 0, override patreon level and hence site locking value with post's. This will allow Creators to lock entire site and then set a different value for individual posts for access. Ie, site locking is $5, but one particular post can be $10, and it will require $10 to see. 
+			
+			if ( $post_level !=0 ) {
+				$patreon_level = $post_level;
+			}
+			 
+			$user                           = wp_get_current_user();
+			$user_pledge_relationship_start = Patreon_Wordpress::get_user_pledge_relationship_start();
+			$user_patronage                 = Patreon_Wordpress::getUserPatronage();
+			$user_lifetime_patronage        = Patreon_Wordpress::get_user_lifetime_patronage();
+			$declined                       = Patreon_Wordpress::checkDeclinedPatronage( $user );
+			
+			
+			// Check if post was set for active patrons only
+			$patreon_active_patrons_only = get_post_meta( $post->ID, 'patreon-active-patrons-only', true );
+			
+			// Check if specific total patronage is given for this post:
+			$post_total_patronage_level = get_post_meta( $post->ID, 'patreon-total-patronage-level', true );
+		
+		
+			$hide_content = true;
+			$reason = 'active_pledge_not_enough';
+		
+			if ( !( $user_patronage == false
+				|| $user_patronage < ( $patreon_level * 100 )
+				|| $declined ) ) {
+					
+				$hide_content = false;
+				
+				// Seems valid patron. Lets see if active patron option was set and the user fulfills it
+				
+				if ( $patreon_active_patrons_only == '1'
+				AND $user_pledge_relationship_start >= strtotime( get_the_date( '', $post->ID ) ) ) {
+					$hide_content = true;
+					$reason = 'not_active_patron_at_post_date';
+				}
+				
+			}	
+		
+			if ( $post_total_patronage_level !='' AND $post_total_patronage_level > 0) {
+				
+				// Total patronage set if user has lifetime patronage over this level, we let him see the content
+				if( $user_lifetime_patronage >= $post_total_patronage_level * 100 ) {
+					$hide_content = false;
+					$reason = 'patron_fulfills_total_historical_pledge_requirement';
+				}
+				
+			}
+				
+			
+		}
+	
+	}
 	
 }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -851,14 +851,14 @@ class Patreon_Wordpress {
 			
 			// Seems valid patron. Lets see if active patron option was set and the user fulfills it
 			
-			if ( $patreon_active_patrons_only == '1'
+			if ( $patreon_active_patrons_on2ly == '1'
 			AND $user_pledge_relationship_start >= strtotime( get_the_date( '', $post->ID ) ) ) {
 				$hide_content = true;
 				$reason = 'not_active_patron_at_post_date';
 			}
 			
 		}	
-	
+	$user_lifetime_patronage =100;
 		if ( $post_total_patronage_level !='' AND $post_total_patronage_level > 0) {
 			
 			// Total patronage set if user has lifetime patronage over this level, we let him see the content

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -851,7 +851,7 @@ class Patreon_Wordpress {
 			
 			// Seems valid patron. Lets see if active patron option was set and the user fulfills it
 			
-			if ( $patreon_active_patrons_on2ly == '1'
+			if ( $patreon_active_patrons_only == '1'
 			AND $user_pledge_relationship_start >= strtotime( get_the_date( '', $post->ID ) ) ) {
 				$hide_content = true;
 				$reason = 'not_active_patron_at_post_date';

--- a/patreon.php
+++ b/patreon.php
@@ -36,8 +36,8 @@ define( "PATREON_TEXT_PLEDGE_NOT_ENOUGH", 'Upgrade your Pledge!' );
 define( "PATREON_TEXT_UPGRADE_PLEDGE", 'Upgrade Pledge' );
 define( "PATREON_TEXT_UNLOCK_WITH_PATREON", 'Unlock with Patreon' );
 define( "PATREON_TEXT_UPDATE_PLEDGE", 'Update Pledge' );
-define( "PATREON_TEXT_LOCKED_POST", 'Sorry! This content is for our Patrons who pledge $%%pledgelevel%% and over!' );
-define( "PATREON_TEXT_OVER_BUTTON_1", 'This content is available to Patrons pledging $%%pledgelevel%% or more on Patreon' );
+define( "PATREON_TEXT_LOCKED_POST", 'Sorry! This content is for our Patrons who pledge $%%pledgelevel%% and over' );
+define( "PATREON_TEXT_OVER_BUTTON_1", 'This content is available to Patrons pledging $%%pledgelevel%% or more' );
 define( "PATREON_TEXT_OVER_BUTTON_2", 'Edit your pledge to %%creator%% to $%%pledgelevel%% or more to access this content. You\'re currently pledging $%%currentpledgelevel%%.' );
 define( "PATREON_TEXT_OVER_BUTTON_3", 'Your Patreon payment method appears to be declined. Update your pledge to access this post.' );
 define( "PATREON_VALID_PATRON_POST_FOOTER_TEXT", 'This content is for Patrons pledging $%%pledgelevel%% or more on %%creatorprofileurl%%' );
@@ -68,8 +68,13 @@ These include your Patreon user id, Patreon username, your first, last names and
 If you request that your data be deleted from this website, this data will also be deleted and Patreon functionality will not work. You would need to register on this website and log in to this website with Patreon again in order to re-populate this data and have Patreon functionality working again.' );
 define( "PATREON_NO_CODE_RECEIVED_FROM_PATREON", "Sorry -  No authorization code received from Patreon." );
 define( "PATREON_NO_FLOW_ACTION_PROVIDED", "Nothing to do since no Patreon action was requested." );
-
 define( "PATREON_DIRECT_UNLOCKS_NOT_ON", 'In order to use this feature, direct unlocks need to be turned on. Please refer to <a href="https://www.patreon.com/apps/wordpress">the developer documentation</a>. ' );
+define( "PATREON_TEXT_LOCKED_POST_ACTIVE_PATRONS", 'while having been active patrons on %%post_date%%' );
+define( "PATREON_TEXT_LOCKED_POST_ACTIVE_PATRONS_WITH_TOTAL_PLEDGE", 'or Patrons with total pledge of $%%total_pledge%%' );
+define( "PATREON_CONTRIBUTION_REQUIRED_STOP_MARK", '!' );
+define( "PATREON_TEXT_OVER_BUTTON_4", ' while having been active patrons on %%post_date%%' );
+define( "PATREON_TEXT_OVER_BUTTON_5", ' or Patrons with total $%%total_pledge%% or more pledge' );
+define( "PATREON_TEXT_OVER_BUTTON_6", ' on Patreon' );
 
 include 'classes/patreon_wordpress.php';
 


### PR DESCRIPTION
**Problem**

updatePatreonUser contacts the api on every page load to update the Patreon-linked user's details from Patreon.

- This adds a small TTFB time to page loads for logged in users with linked Patreon accounts.
- It creates extra load on the API.

**Solution**

Make the function contact the API and update details only if last update was earlier than a day or last update day is not found. Have user details updated when users log in via Patreon.

**Verification**

Tested and verified on web-facing production site by using an actual patron account.

**Does this need tests**

No.
