### PR TITLE
Added usermeta to save the time user was last updated. Added conditio…

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -94,6 +94,7 @@ class Patreon_Wordpress {
 		return self::$current_patreon_user = false;
 		
 	}
+	
 	static function updatePatreonUser() {
 
 		/* check if current user is loggedin, get ID */
@@ -105,6 +106,15 @@ class Patreon_Wordpress {
 		$user = wp_get_current_user();
 		if ( $user == false ) {
 			return false;
+		}
+		
+		// Temporarily introduced caching until calls are moved to webhooks #REVISIT
+		
+		$last_update = get_user_meta( $user->ID, 'patreon_user_details_last_updated', true );
+		
+		// If last update time is not empty and it is closer to time() than one day, dont update
+		if ( !( $last_update == '' OR ( ( time() - $last_update ) > 86400 ) ) ) {
+			return false;	
 		}
 
 		/* query Patreon API to get users patreon details */
@@ -137,8 +147,11 @@ class Patreon_Wordpress {
 		if ( $user_response == false ) {
 			return false;
 		}
-
+		
 		if ( isset( $user_response['data'] ) ) {
+			
+			// Set the update time
+			update_user_meta( $user->ID, 'patreon_user_details_last_updated', time() );
 			
 			/* all the details you want to update on wordpress user account */
 			update_user_meta( $user->ID, 'patreon_user', $user_response['data']['attributes']['vanity'] );


### PR DESCRIPTION
**Problem**

updatePatreonUser contacts the api on every page load to update the Patreon-linked user's details from Patreon.

- This adds a small TTFB time to page loads for logged in users with linked Patreon accounts.
- It creates extra load on the API.

**Solution**

Make the function contact the API and update details only if last update was earlier than a day or last update day is not found. Have user details updated when users log in via Patreon.

**Verification**

Tested and verified on web-facing production site by using an actual patron account.

**Does this need tests**

No.
