### PR TITLE
Update advanced lock options text

### DIFF
--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -35,7 +35,7 @@ class Patreon_API {
 		if ( $api_return['included'][0]['attributes']['last_charge_status'] != 'Paid' ) {
 			$api_return['included'][0]['attributes']['declined_since'] = $api_return['included'][0]['attributes']['last_charge_date'];
 		}
-			
+
 		return $api_return;
 	}
 	

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -42,7 +42,7 @@ class Patron_Metabox {
 
 	function patreon_plugin_meta_box( $object, $box ) { 
 			
-		$label    = 'Add a minimum Patreon contribution required to access this content.  (Makes entire post patron only)';
+		$label    = 'Require Patreon pledge of this dollar amount or higher to view this post.  (Makes entire post patron only)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#section_1" target="_blank">(?)</a>';
 		$readonly = '';
 		
 		if ( !get_option( 'patreon-creator-id', false ) ) {
@@ -63,7 +63,7 @@ class Patron_Metabox {
 
 		<?php
 		
-		$label    = 'Active patrons only (optional) - if on, only patrons active at and before this post\'s publishing date will be able to see this content )';
+		$label    = 'Require an active pledge at the time of this post’s creation to view this post. (optional) <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#section_2" target="_blank">(?)</a>';
 		$readonly = '';
 		
 		if ( !get_option( 'patreon-creator-id', false ) ) {
@@ -82,7 +82,7 @@ class Patron_Metabox {
 
 		<?php
 		
-		$label    = 'Total patronage (optional) - any patron above total lifetime patronage $ value entered below can see this content';
+		$label    = 'Require a lifetime pledge amount greater than this amount to view this post. (optional) <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#section_3" target="_blank">(?)</a>';
 		$readonly = '';
 		
 		if ( !get_option( 'patreon-creator-id', false ) ) {


### PR DESCRIPTION
**Problem**

Updated text was provided for new advanced locking options. Help links needed to be added.

**Solution**

Updated text, added relevant links to sections inside a forum help topic as was proposed.

![updated-text](https://user-images.githubusercontent.com/13155428/45973814-c7a8c800-c03f-11e8-9ff7-f55b8c66fea4.jpg)

Relevant forum help topic (to be updated before 1.2.0 release)

https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#section_1

**Verification**

As seen in screenshot, the text is updated and help links properly link out to the help topic.

**Does this need tests**

No