### PR TITLE
1 2 1 changes

### DIFF
--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -125,16 +125,16 @@ class Patreon_Frontend {
 		
 			// Wrap message and buttons in divs for responsive interface mechanics
 			
-			// Hide the custom banner if no custom banner was saved
+			$contribution_required = '<div class="patreon-locked-content-message">' . $contribution_required . '</div>';
 			
-			if ( $custom_universal_banner AND $custom_universal_banner !='' ) {
+			// But hide the custom banner if no custom banner was saved
 			
-				$contribution_required = apply_filters( 'ptrn/final_state_main_banner_message', '<div class="patreon-locked-content-message">' . $contribution_required . '</div>', $patreon_level, $post );
-			
+			if ( !$custom_universal_banner OR $custom_universal_banner =='' ) {
+				$contribution_required = '';
 			}
-			else {
-				$contribution_required = '';				
-			}
+			
+			// Still apply the filters so it can be modified by 3rd party code
+			$contribution_required = apply_filters( 'ptrn/final_state_main_banner_message', $contribution_required, $patreon_level, $post );
 			
 			$button_args = array();
 			

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -52,10 +52,18 @@ class Patreon_OAuth {
 		);
 
 		$response = wp_remote_post( $api_endpoint, $api_request );
-
-		$response_decoded = json_decode($response['body'], true );
 		
-		if(is_array($response_decoded)) {
+		if ( is_wp_error( $response ) ) {
+			
+			$result                    = array( 'error' => $response->get_error_message() );
+			$GLOBALS['patreon_notice'] = $response->get_error_message();
+			return $result;
+			
+		}	
+		
+		$response_decoded = json_decode( $response['body'], true );
+		
+		if ( is_array( $response_decoded ) ) {
 			return $response_decoded;
 		}
 		

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -906,7 +906,7 @@ class Patreon_Wordpress {
 		
 		// If the lock or not array is large than 50, snip the first item
 		
-		if ( count( self::$lock_or_not > 50 ) ) {
+		if ( count( self::$lock_or_not ) > 50  ) {
 			array_shift( self::$lock_or_not );
 		}
 		

--- a/patreon.php
+++ b/patreon.php
@@ -4,7 +4,7 @@
 Plugin Name: Patreon Wordpress
 Plugin URI: https://www.patreon.com/apps/wordpress
 Description: Patron-only content, directly on your website.
-Version: 1.2.0
+Version: 1.2.1
 Author: Patreon <platform@patreon.com>
 Author URI: https://patreon.com
 */
@@ -59,7 +59,7 @@ define( "PATREON_ADMIN_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons on
 define( "PATREON_CREATOR_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons only, it\'s not locked for you because you are logged in as the Patreon creator' );
 define( "PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST", 'Post is already public. If you would like to lock this post, please set a pledge level for it' );
 define( "PATREON_NO_POST_ID_TO_UNLOCK_POST", 'Sorry - could not get the post id for this locked post' );
-define( "PATREON_WORDPRESS_VERSION", '1.2.0' );
+define( "PATREON_WORDPRESS_VERSION", '1.2.1' );
 define( "PATREON_WORDPRESS_PLUGIN_SLUG", plugin_basename( __FILE__ ) );
 define( "PATREON_PRIVACY_POLICY_ADDENDUM", '<h2>Patreon features in this website</h2>In order to enable you to use this website with Patreon services, we save certain functionally important Patreon information about you in this website if you log in with Patreon.
 <br /><br />

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressorg@patreon.com, codebard
 Tags: patreon, membership, members
 Requires at least: 4.0
 Tested up to: 4.9.8
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -89,6 +89,12 @@ It is  difficult to protect videos due the intensive bandwidth requirements of h
 
 
 == Changelog ==
+
+= 1.2.1 =
+
+* A bug causing posts to display earlier posts' locking info in locked excerpts was fixed
+* oAuth process now returns errors in case Patreon API can't be contacted due to maintenance or any other reason
+* 3rd party code and plugins can now override custom banner even if no custom banner was saved in plugin options
 
 = 1.2.0 =
 


### PR DESCRIPTION
**Problem**

A small host of issues and changes after 1.2.0 release. 

- A bug was causing posts to display earlier posts' locking info in locked excerpts. 

- In case of non-connectivity with Patreon API or maintenance at Patreon API, the plugin wasnt returning proper error due to not handling the WP_error return. 

- A potential bug that could cause 3rd party code/plugins to not be able to modify custom banner was discovered.

**Solution**

- lock_or_not function had a variable cache implemented to hold mappings of post ids to locking decision results. This not only fixes this bug, but allows post listings to be performed slightly faster since not needing to re-process locking logic.

- Code to catch any non-connectivity error or any error that resulted in WP_error being returned was added to patreon_oauth.php. This will display the error in the relevant post's error reporting section inside the locking interface when it happens.

- Code to unset custom banner if it was not set by the user in plugin settings was moved before filter application. This will allow any plugin to override custom banner even if its not set.

**Verification**

All tested. Code in this branch has been out to Pro users in stages since a week and works without issues.

**Does this need tests**

No.