### PR TITLE
Commented out a code piece which could cause a user who was doing oAu…

### DIFF
--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -67,9 +67,9 @@ class Patreon_OAuth {
 			return $response_decoded;
 		}
 		
-		echo $response['body'];
-		wp_die();
-
+		// Commented out to address issues caused by Patreon's maintenance in between 01 - 02 Feb 2019 - the plugin was showing Patreon's maintenance page at WP sites yin certain cases
+		// echo $response['body'];
+		// wp_die();
 	}
 	
 }


### PR DESCRIPTION
**Problem**

When non JSON returns with 200 status code was received from Patreon API (like during maintenance), the Patreon_OAuth class' update_token function's error handling code was showing Patreon maintenance page and dying out. 

This happened when the plugin attempted to refresh a creator access token, a user's access token, or user's Patreon info during a maintenance.

**Solution**

The code that exposes the non JSON 200 status coded returns from Patreon was commented out as a hotfix. This fixes the problem.

**Verification**

Was tested by imitating non JSON return from Patreon API with 200 status code. Fixes the problem.

**Does this need tests**

No.