### PR TITLE
Get save user avatar

### DIFF
--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -24,6 +24,7 @@ class Patreon_Frontend {
 		add_action( 'register_form', array( $this, 'displayPatreonLoginButtonInLoginForm' ) );
 		add_filter( 'the_content', array( $this, 'protectContentFromUsers'), PHP_INT_MAX - 5 );
 		add_shortcode( 'patreon_login_button', array( $this,'LoginButtonShortcode' ) );
+		add_filter('get_avatar', array( $this, 'show_patreon_avatar' ), 10, 5);
 
 		self::$messages_map = array(
 			'patreon_cant_login_strict_oauth'            => PATREON_CANT_LOGIN_STRICT_OAUTH,		
@@ -1072,6 +1073,42 @@ class Patreon_Frontend {
 			return Patreon_Frontend::showPatreonLoginButton();
 		}
 		
+	}
+	public static function show_patreon_avatar( $avatar, $id_or_email, $size, $default, $alt ) {
+		
+		// Checks if the user has a Patreon avatar saved, and returns that avatar in place of WP/site default
+		$user = false;
+
+		if ( is_numeric( $id_or_email ) ) {
+
+			$id = (int) $id_or_email;
+			$user = get_user_by( 'id' , $id );
+
+		} elseif ( is_object( $id_or_email ) ) {
+
+			if ( ! empty( $id_or_email->user_id ) ) {
+				$id = (int) $id_or_email->user_id;
+				$user = get_user_by( 'id' , $id );
+			}
+
+		} else {
+			$user = get_user_by( 'email', $id_or_email );	
+		}
+
+		if ( $user && is_object( $user ) ) {
+			
+			// Get user's Patreon avatar meta:
+			
+			$user_patreon_avatar = get_user_meta( $user->ID, 'patreon-avatar-url', true );
+			
+			// Override avatar if there is a saved Patreon avatar
+			if ( $user_patreon_avatar != '' ) {
+				$avatar = $user_patreon_avatar;
+			}
+		}
+		
+		return '<img alt="'.$alt.'" src="'.$avatar.'" class="avatar avatar-"'.$size.' photo" height="'.$size.'" width="'.$size.'" />';
+
 	}
 	
 }

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -1103,7 +1103,7 @@ class Patreon_Frontend {
 			
 			// Override avatar if there is a saved Patreon avatar
 			if ( $user_patreon_avatar != '' ) {
-				$avatar = '<img alt="'.$alt.'" src="'.$user_patreon_avatar.'" class="avatar avatar-"'.$size.' photo" height="'.$size.'" width="'.$size.'" />'
+				$avatar = '<img alt="'.$alt.'" src="'.$user_patreon_avatar.'" class="avatar avatar-"'.$size.' photo" height="'.$size.'" width="'.$size.'" />';
 			}
 		}
 		

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -1103,11 +1103,11 @@ class Patreon_Frontend {
 			
 			// Override avatar if there is a saved Patreon avatar
 			if ( $user_patreon_avatar != '' ) {
-				$avatar = $user_patreon_avatar;
+				$avatar = '<img alt="'.$alt.'" src="'.$user_patreon_avatar.'" class="avatar avatar-"'.$size.' photo" height="'.$size.'" width="'.$size.'" />'
 			}
 		}
 		
-		return '<img alt="'.$alt.'" src="'.$avatar.'" class="avatar avatar-"'.$size.' photo" height="'.$size.'" width="'.$size.'" />';
+		return $avatar;
 
 	}
 	

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -1101,9 +1101,14 @@ class Patreon_Frontend {
 			
 			$user_patreon_avatar = get_user_meta( $user->ID, 'patreon-avatar-url', true );
 			
+			if ( !$size OR !is_numeric($size) OR $size == 0 ) {
+				// Set size to WP default 48 if no size was provided by WP installation for whatsoever reason
+				$size = 48;
+			}
+			
 			// Override avatar if there is a saved Patreon avatar
 			if ( $user_patreon_avatar != '' ) {
-				$avatar = '<img alt="'.$alt.'" src="'.$user_patreon_avatar.'" class="avatar avatar-"'.$size.' photo" height="'.$size.'" width="'.$size.'" />';
+				$avatar = "<img alt='{$alt}' src='{$user_patreon_avatar}' class='avatar avatar-{$size} photo' height='{$size}' width='{$size}' />";
 			}
 		}
 		


### PR DESCRIPTION
**Problem**

The login/registration process of plugin for logging in or registering users via Patreon flow did not used to grab user's avatar from Patreon.

**Solution**

If there doesnt exist any specific avatar for he user who is logging in, or if the user is just being registered via Patreon log in, grab the user's remote Patreon avatar if it exists, save it in WP media uploads folder, then set it as the avatar.

If the user already exists at WordPress and has previously existing avatar, do not change it.

**Verification**

Tested at development and test sites, works normally.

**Does this need tests**

Tested, works.
