### PR TITLE
Investigate creator token issues

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -630,13 +630,14 @@ class Patreon_Wordpress {
 				delete_option( 'patreon-mailing-list-notice-shown' );
 				delete_option( 'patreon-rate-plugin-notice-shown' );
 				delete_option( 'patreon-file-locking-feature-notice-shown' );
+					
+				// Transitional code to fix creator id pulling bug - campaign id was being pulled instead. Can be removed in 1-2 versions
+				
+				delete_option( 'patreon-creator-id' );
+				delete_option( 'patreon-campaign-id' );
 				
 			}
 
-			// Transitional code to fix creator id pulling bug - campaign id was being pulled instead. Can be removed in 1-2 versions
-			
-			delete_option( 'patreon-creator-id' );
-			delete_option( 'patreon-campaign-id' );
 			
 		}
 		

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -630,11 +630,6 @@ class Patreon_Wordpress {
 				delete_option( 'patreon-mailing-list-notice-shown' );
 				delete_option( 'patreon-rate-plugin-notice-shown' );
 				delete_option( 'patreon-file-locking-feature-notice-shown' );
-					
-				// Transitional code to fix creator id pulling bug - campaign id was being pulled instead. Can be removed in 1-2 versions
-				
-				delete_option( 'patreon-creator-id' );
-				delete_option( 'patreon-campaign-id' );
 				
 			}
 


### PR DESCRIPTION
**Problem**

The transitional code for deleting creator and campaign id was causing some issues due to also triggering after other plugin's updates - forcing the plugin to re-acquire these. This could have caused occasional locking of $ level box in locking interface in post editor.

**Solution**

Transitional code was removed since 1.2.x seems to have propagated to 80%+ of users.

**Verification**

The code is visibly removed from the class as can be seen in the commit.

**Does this need tests**

This change doesnt require tests. 