### PR TITLE
Fix user creation without token return

### DIFF
--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -42,9 +42,11 @@ class Patreon_Frontend {
 			'no_code_receved_from_patreon'               => PATREON_NO_CODE_RECEIVED_FROM_PATREON,
 			'no_patreon_action_provided_for_flow'        => PATREON_NO_FLOW_ACTION_PROVIDED,
 			'patreon_direct_unlocks_not_turned_on'       => PATREON_DIRECT_UNLOCKS_NOT_ON,
+			'patreon_couldnt_acquire_user_details'       => PATREON_COULDNT_ACQUIRE_USER_DETAILS,
 		);
 		
 	}
+	
 	function patreonEnqueueJs() {
 		
 		wp_register_script( 'patreon-wordpress-js', PATREON_PLUGIN_ASSETS . '/js/app.js', array( 'jquery' ) );

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -66,7 +66,7 @@ class Patreon_OAuth {
 		if ( is_array( $response_decoded ) ) {
 			return $response_decoded;
 		}
-		
+	
 		// Commented out to address issues caused by Patreon's maintenance in between 01 - 02 Feb 2019 - the plugin was showing Patreon's maintenance page at WP sites yin certain cases
 		// echo $response['body'];
 		// wp_die();

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -89,7 +89,7 @@ class Patreon_Routing {
 				
 				// Login intent. 
 				
-				$final_redirect = home_url();
+				$final_redirect = wp_login_url();
 				
 				if( isset( $wp->query_vars['patreon-final-redirect'] ) ) {
 					
@@ -300,6 +300,7 @@ class Patreon_Routing {
 			exit;
 			
 		}
+		
 		if ( strpos( $_SERVER['REQUEST_URI'], '/patreon-authorization/' ) !== false ) {
 
 			// First slap the noindex header so search engines wont index this page:
@@ -363,6 +364,19 @@ class Patreon_Routing {
 					$api_client = new Patreon_API( $tokens['access_token'] );
 					
 					$user_response = $api_client->fetch_user();
+					
+					// Check out if there is a proper user return. 
+					
+					if( !isset( $user_response['data']['id'] ) ) {
+						
+						// We didnt get user info back from the API. Cancel with a message
+							
+						$redirect = add_query_arg( 'patreon_message', 'patreon_couldnt_acquire_user_details', $redirect );
+						
+						wp_redirect( $redirect );
+						exit;						
+					
+					}
 					
 					if( apply_filters( 'ptrn/force_strict_oauth', get_option( 'patreon-enable-strict-oauth', false ) ) ) {
 						$user = Patreon_Login::updateLoggedInUserForStrictoAuth( $user_response, $tokens, $redirect );

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -367,7 +367,7 @@ class Patreon_Routing {
 					
 					// Check out if there is a proper user return. 
 					
-					if( !isset( $user_response['data']['id'] ) ) {
+					if( !is_array( $user_response ) OR !isset( $user_response['data']['id'] ) ) {
 						
 						// We didnt get user info back from the API. Cancel with a message
 							

--- a/patreon.php
+++ b/patreon.php
@@ -80,6 +80,7 @@ define( "PATREON_TEXT_OVER_BUTTON_8", 'This content is available exclusively to 
 define( "PATREON_TEXT_OVER_BUTTON_9", 'This content is available exclusively to Patreon members pledging $%%pledgelevel%% or more, or having at least $%%total_pledge%% pledged in total.' );
 define( "PATREON_TEXT_OVER_BUTTON_10", 'This content is available exclusively to Patreon members pledging $%%pledgelevel%% or more at the time this content was posted, or having at least $%%total_pledge%% pledged in total.' );
 define( "PATREON_TEXT_OVER_BUTTON_11", 'This content is available exclusively to Patreon members pledging $%%pledgelevel%% or more at the time this content was posted.' );
+define( "PATREON_COULDNT_ACQUIRE_USER_DETAILS", 'Sorry. Could not acquire your info from Patreon. Please try again later.' );
 
 include 'classes/patreon_wordpress.php';
 


### PR DESCRIPTION
**Problem**

When an unexpected HTML or non JSON return (but an existing return instead of error) was returned from Patreon API (potentially due to a maintenance page, or cloudflare error page in cases like the ones from last summer) a new user logging in via Patreon was still being registered in the remote WP site.

This could have potentially caused creation of spammy accounts in remote WP sites if Patreon API was returning HTML for a duration, only for the duration HTML returns lasted. The situation did not have any security concerns attached. 

**Solution**

Added a check for a proper return from Patreon API that prevents user registration/login if return from Patreon API is received in HTML form. Added a notice to tell users that they are not able to log in because their details werent acquired from Patreon.

**Verification**

Tested in live test site, works.

**Does this need tests**

Not necessary. 