### PR TITLE
Add setup info collector

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -1149,5 +1149,28 @@ class Patreon_Wordpress {
 		return apply_filters( 'ptrn/lock_or_not', self::add_to_lock_or_not_results( $post_id, $result) , $post_id, $declined, $user );
 		
 	}
+	public static function collect_app_info() {
+		
+		// Collects app information from WP site to be used in client settins at Patreon
+		
+		$blog_info = get_bloginfo();
+		
+		$parsed_home_url = parse_url( $blog_info['wpurl'] );
+		
+		$company_domain = $parsed_home_url['host'];
+		
+		$app_info = array(
+			'app_name'         => $blog_info['name'],
+			'app_desc'         => $blog_info['description'],
+			'author'           => $blog_info['name'],
+			'company_domain'   => $company_domain,
+			'icon_url'         => PATREON_PLUGIN_ASSETS . '/img/patreon_wordpress_app_icon',
+			'redirect_uri'     => site_url( '/patreon-authorization/' ),
+			'api_version'      => '1',
+		);
+		
+		return $app_info;
+		
+	}
 	
 }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -1152,19 +1152,17 @@ class Patreon_Wordpress {
 	public static function collect_app_info() {
 		
 		// Collects app information from WP site to be used in client settins at Patreon
-		
-		$blog_info = get_bloginfo();
-		
-		$parsed_home_url = parse_url( $blog_info['wpurl'] );
+				
+		$parsed_home_url = parse_url( get_bloginfo( 'url' ) );
 		
 		$company_domain = $parsed_home_url['host'];
 		
 		$app_info = array(
-			'app_name'         => $blog_info['name'],
-			'app_desc'         => $blog_info['description'],
-			'author'           => $blog_info['name'],
+			'app_name'         => get_bloginfo( 'name' ),
+			'app_desc'         => 'Patreon app for ' . get_bloginfo( 'name' ),
+			'author'           => get_bloginfo( 'name' ),
 			'company_domain'   => $company_domain,
-			'icon_url'         => PATREON_PLUGIN_ASSETS . '/img/patreon_wordpress_app_icon',
+			'icon_url'         => PATREON_PLUGIN_ASSETS . '/img/patreon_wordpress_app_icon.png',
 			'redirect_uri'     => site_url( '/patreon-authorization/' ),
 			'api_version'      => '1',
 		);


### PR DESCRIPTION
**Problem**

We needed to collect info from the local WP site in order to post it to Patreon so that Patreon can create the site's oAuth app credentials.

**Solution**

A function to collect info from WP installation's global information was added.

**Verification**

The function returns an array of info to be posted to Patreon. Tested with setup wizard in its own branch.

**Does this need tests**

no