### PR TITLE
Prevent notices if setup is being done

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -60,7 +60,7 @@ class Patreon_Wordpress {
 		add_action( 'init', 'Patreon_Login::checkTokenExpiration' );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueueAdminScripts' ) );
 		add_action( 'upgrader_process_complete', 'Patreon_Wordpress::AfterUpdateActions', 10, 2 );
-		add_action( 'admin_notices', array( $this, '3ages' ) );
+		add_action( 'admin_notices', array( $this, 'AdminMessages' ) );
 		add_action( 'init', array( $this, 'transitionalImageOptionCheck' ) );
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_section' ), 20 ) ;
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ) );

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -60,7 +60,7 @@ class Patreon_Wordpress {
 		add_action( 'init', 'Patreon_Login::checkTokenExpiration' );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueueAdminScripts' ) );
 		add_action( 'upgrader_process_complete', 'Patreon_Wordpress::AfterUpdateActions', 10, 2 );
-		add_action( 'admin_notices', array( $this, 'AdminMessages' ) );
+		add_action( 'admin_notices', array( $this, '3ages' ) );
 		add_action( 'init', array( $this, 'transitionalImageOptionCheck' ) );
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_section' ), 20 ) ;
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ) );
@@ -666,6 +666,11 @@ class Patreon_Wordpress {
 	public static function AdminMessages() {
 		
 		// This function processes any message or notification to display once after updates.
+		
+		// Skip showing any notice if setup is being done
+		if ( get_option( 'patreon-setup_is_being_done', false ) ) {
+			return;
+		}
 		
 		$mailing_list_notice_shown = get_option( 'patreon-mailing-list-notice-shown', false );
 		


### PR DESCRIPTION
**Problem**

We needed to prevent admin notices from being shown is setup was in progress.

**Solution**

A check for current setup page was added to prevent showing notices. Additionally the notice function was made to only show the setup needed notice if setup was not done - when not on setup page.

**Verification**

This can be tested with easy_setup_wizard_pre_pr_test_branch. The notices are not shown on setup pages, and only setup needed notice is shown when on other admin pages.

**Does this need tests**

no