### PR TITLE
Add tier select to lock metabox

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -131,4 +131,39 @@ jQuery( function( $ ) {
 		});		
 		
 	});
+		
+	// Only trigger if the select dropdown is actually present
+	if ( jQuery( "#patreon_level_select" ).length ) {
+		
+		var pw_input_target = jQuery( "#patreon_level_select" );
+		var pw_post_id = pw_input_target.attr( 'pw_post_id' );
+			
+		jQuery.ajax({
+			url: ajaxurl,
+			async: true, // Just to make sure
+			type:"POST",
+			dataType : 'html',
+			data: {
+				action: 'patreon_wordpress_populate_patreon_level_select',
+				pw_post_id: pw_post_id,
+			},
+			success: function( response ) {
+				jQuery( pw_input_target ).empty();
+				jQuery( pw_input_target ).html( response );
+				
+			},
+			error: function( response ) {
+				jQuery( pw_input_target ).empty();
+				jQuery( pw_input_target ).html( response );
+			},
+			statusCode: {
+				500: function(error) {
+					jQuery( pw_input_target ).empty();
+					jQuery( pw_input_target ).html( 'Sorry - error (500)' );
+				}
+			}
+		});	
+		
+	}
+	
 });

--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -78,10 +78,22 @@ class Patreon_API {
 		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
 		
 		if ( $v2 ) {
-			return $this->__get_json( "campaigns?include=rewards,creator,goals" );
+			return $this->__get_json( "campaigns?include=tiers,creator,goals", $v2 );
 		}
 
 		return $this->__get_json( "current_user/campaigns?include=rewards,creator,goals" );
+		
+	}
+	
+	public function fetch_tiers( $v2 = false ) {
+		
+		// Below conditional and different endpoint can be deprecated to only use v2 api after transition period
+		
+		if ( $v2 ) {
+			return $this->__get_json( "campaigns?include=tiers,creator,goals", $v2 );
+		}
+
+		return $this->__get_json( "current_user/campaigns?include=rewards" );
 		
 	}
 

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -44,13 +44,13 @@ class Patron_Metabox {
 	
 		$current_user = wp_get_current_user();
 			
-		$label    = 'Require Patreon pledge of this dollar amount or higher to view this post.  (Makes entire post patron only)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-1" target="_blank">(?)</a>';
+		$label    = 'Require the below membership tier or higher to view this post. (Makes entire post patron only)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-1" target="_blank">(?)</a>';
 		$readonly = '';
 		
 		if ( !get_option( 'patreon-creator-id', false ) ) {
 			
 			$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin ").'">here</a>';
-			$readonly = " readonly";
+			$disabled = " disabled";
 			
 		}
 
@@ -60,7 +60,7 @@ class Patron_Metabox {
 		<p>
 			<label for="patreon-level"><?php _e( $label, '1' ); ?></label>
 			<br><br>
-			<strong>&#36; </strong><input type="text" id="patreon-level" name="patreon-level" value="<?php echo get_post_meta( $object->ID, 'patreon-level', true ); ?>" <?php echo $readonly ?>>
+			<select name="patreon-level"<?php echo $disabled ?>><?php echo Patreon_Wordpress::make_tiers_select(); ?></select>			
 		</p>
 		
 		<?php 
@@ -75,11 +75,26 @@ class Patron_Metabox {
 		?> 		
 		
 		<div <?php echo $advanced_post_options_toggle_status_display ?>id="patreon-wordpress-advanced-options-toggle">
+		<?php
+		
+			if ( !get_option( 'patreon-creator-id', false ) ) {
+				
+				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin ").'">here</a>';
+				$readonly = " readonly";
+				
+			}
+		?>
+		
+			<p>
+			<label for="patreon-level"><?php _e( $label, '1' ); ?></label>
+			<br><br>
+			<strong>&#36; </strong><input type="text" id="patreon-level" name="patreon-level" value="<?php echo get_post_meta( $object->ID, 'patreon-level', true ); ?>" <?php echo $readonly ?>>		
+		</p>
 		
 			<?php
 			
 			$label    = 'Require an active pledge at the time of this post’s creation to view this post. (optional) <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-2" target="_blank">(?)</a>';
-		$readonly = '';
+			$readonly = '';
 			
 			if ( !get_option( 'patreon-creator-id', false ) ) {
 				
@@ -98,7 +113,7 @@ class Patron_Metabox {
 			<?php
 			
 			$label    = 'Require a lifetime pledge amount greater than this amount to view this post. (optional) <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-3" target="_blank">(?)</a>';
-		  $readonly = '';
+			$readonly = '';
 			
 			if ( !get_option( 'patreon-creator-id', false ) ) {
 				

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -77,7 +77,7 @@ class Patron_Metabox {
 		<div <?php echo $advanced_post_options_toggle_status_display ?>id="patreon-wordpress-advanced-options-toggle">
 		<?php
 		
-			$label    = 'Require the below precise $ membership value or over to view this post. (Makes entire post patron only)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-1" target="_blank">(?)</a>';
+			$label    = 'Require the below precise $ monthly membership or over to view this post. (optional - overrides the above select box when used)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-1" target="_blank">(?)</a>';
 			$readonly = '';		
 		
 			if ( !get_option( 'patreon-creator-id', false ) ) {

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -54,13 +54,13 @@ class Patron_Metabox {
 			
 		}
 
-			wp_nonce_field( basename( __FILE__ ), 'patreon_metabox_nonce' ); 
-			
+			wp_nonce_field( basename( __FILE__ ), 'patreon_metabox_nonce' );
+				
 		?>
 		<p>
 			<label for="patreon-level"><?php _e( $label, '1' ); ?></label>
 			<br><br>
-			<select name="patreon-level"<?php echo $disabled ?>><?php echo Patreon_Wordpress::make_tiers_select(); ?></select>			
+			<select id="patreon_level_select" name="patreon-level"<?php echo $disabled ?> pw_post_id="<?php echo $object->ID; ?>"><option value="<?php echo get_post_meta( $object->ID, 'patreon-level', true ); ?>">Loading...</option></select>			
 		</p>
 		
 		<?php 
@@ -69,7 +69,7 @@ class Patron_Metabox {
 						
 			$advanced_post_options_toggle_status_display = 'style=" display: block;" ';
 			
-			if( $advanced_post_options_toggle_status == '' OR $advanced_post_options_toggle_status == 'off' ) {
+			if ( $advanced_post_options_toggle_status == '' OR $advanced_post_options_toggle_status == 'off' ) {
 				$advanced_post_options_toggle_status_display = 'style=" display: none;" ';
 			}
 		?> 		
@@ -89,7 +89,7 @@ class Patron_Metabox {
 		?>
 		
 			<p>
-			<label for="patreon-level"><?php _e( $label, '1' ); ?></label>
+			<label for="patreon-level-exact"><?php _e( $label, '1' ); ?></label>
 			<br><br>
 			<strong>&#36; </strong><input type="text" id="patreon-level-exact" name="patreon-level-exact" value="<?php echo get_post_meta( $object->ID, 'patreon-level', true ); ?>" <?php echo $readonly ?>>		
 		</p>

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -77,6 +77,9 @@ class Patron_Metabox {
 		<div <?php echo $advanced_post_options_toggle_status_display ?>id="patreon-wordpress-advanced-options-toggle">
 		<?php
 		
+			$label    = 'Require the below precise $ membership value or over to view this post. (Makes entire post patron only)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-1" target="_blank">(?)</a>';
+			$readonly = '';		
+		
 			if ( !get_option( 'patreon-creator-id', false ) ) {
 				
 				$label    = 'Post locking won\'t work without Creator ID. Please confirm you have it <a href="'.admin_url( "?page=patreon-plugin ").'">here</a>';
@@ -88,7 +91,7 @@ class Patron_Metabox {
 			<p>
 			<label for="patreon-level"><?php _e( $label, '1' ); ?></label>
 			<br><br>
-			<strong>&#36; </strong><input type="text" id="patreon-level" name="patreon-level" value="<?php echo get_post_meta( $object->ID, 'patreon-level', true ); ?>" <?php echo $readonly ?>>		
+			<strong>&#36; </strong><input type="text" id="patreon-level-exact" name="patreon-level-exact" value="<?php echo get_post_meta( $object->ID, 'patreon-level', true ); ?>" <?php echo $readonly ?>>		
 		</p>
 		
 			<?php
@@ -166,18 +169,18 @@ class Patron_Metabox {
 		}
 
 		$patreon_level = get_post_meta( $post_id, 'patreon-level', true );
-
-		if ( $new_patreon_level && $patreon_level == '' ) {
+		
+		// Now, an exception for the old metabox which was moved to patreon-level-exact - if it is different from the value already saved or from 0, override the select box with its value since it would mean a specific override initiated by user.
+		
+		if( isset( $_POST['patreon-level-exact'] ) && is_numeric( $_POST['patreon-level-exact'] ) ) {
 			
-			add_post_meta( $post_id, 'patreon-level', $new_patreon_level, true );
+			if ( $_POST['patreon-level-exact'] != $patreon_level ) {
+				$new_patreon_level = $_POST['patreon-level-exact'];
+			}
 			
-		} else if ( ( $new_patreon_level || $new_patreon_level == 0 || $new_patreon_level == '0' ) && $new_patreon_level != $patreon_level ) {
-			
-			update_post_meta( $post_id, 'patreon-level', $new_patreon_level );
-
-		} else if ( $new_patreon_level == '' && $patreon_level ) {
-			delete_post_meta( $post_id, 'patreon-level', $patreon_level );
 		}
+		
+		update_post_meta( $post_id, 'patreon-level', $new_patreon_level );
 
 		// Handles active patrons only toggle
 		if ( isset( $_POST['patreon-active-patrons-only']) && $_POST['patreon-active-patrons-only'] != '') {

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -1236,7 +1236,7 @@ class Patreon_Wordpress {
 					$matching_level_found = true;
 				}
 				
-				$select_options .= '<option value="'.$creator_info['included'][$key]['id'].'"'.$selected.'>'. $label . '</option>';
+				$select_options .= '<option value="' . ( $reward['attributes']['amount_cents'] / 100 ) . '"'.$selected.'>'. $label . '</option>';
 			}
 			
 		}

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -171,7 +171,7 @@ class Patreon_Wordpress {
 
 	}
 	public static function checkPatreonCreatorID() {
-		
+				
 		// Check if creator id doesnt exist. Account for the case in which creator id was saved as empty by the Creator
 
 		if ( !get_option( 'patreon-creator-id', false ) OR get_option( 'patreon-creator-id', false )== '' ) {
@@ -1171,7 +1171,7 @@ class Patreon_Wordpress {
 		}
 		
 		$post = get_post( $_REQUEST['pw_post_id'] );
-		
+				
 		echo Patreon_Wordpress::make_tiers_select( $post );
 		exit;
 		
@@ -1188,8 +1188,13 @@ class Patreon_Wordpress {
 		
 		// This function makes a select box with rewards and reward ids from creator's campaign to be used in post locking and site locking
 		
+		
+		// When we move to webhooks, this code can be changed to read from the already present creator details
 		$api_client = new Patreon_API( get_option( 'patreon-creators-access-token', false ) );
-		$creator_info = $api_client->fetch_campaign_and_patrons();
+		$creator_info = $api_client->fetch_tiers();
+		
+		// Save creator tiers for using in locked interface text
+		update_option( 'patreon-creator-tiers', $creator_info );
 
 		// Set the select to default
 		$select_options = PATREON_TEXT_YOU_HAVE_NO_REWARDS_IN_THIS_CAMPAIGN;
@@ -1272,7 +1277,7 @@ class Patreon_Wordpress {
 			
 		}
 		
-		return apply_filters( 'ptrn/post_locking_tier_selection', $select_options, $post );
+		return apply_filters( 'ptrn/post_locking_tier_select', $select_options, $post );
 	
 	}
 	

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -66,6 +66,7 @@ class Patreon_Wordpress {
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_for_update' ) );
 		add_action( 'wp_ajax_patreon_wordpress_dismiss_admin_notice', array( $this, 'dismiss_admin_notice' ), 10, 1 );
 		add_action( 'wp_ajax_patreon_wordpress_toggle_option', array( $this, 'toggle_option' ), 10, 1 );
+		add_action( 'wp_ajax_patreon_wordpress_populate_patreon_level_select', array( $this, 'populate_patreon_level_select_from_ajax' ), 10, 1 );
 
 	}
 	public static function getPatreonUser( $user ) {
@@ -776,6 +777,7 @@ class Patreon_Wordpress {
 		
 	}	
 	public function dismiss_admin_notice() {
+		
 		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
@@ -1149,7 +1151,36 @@ class Patreon_Wordpress {
 		return apply_filters( 'ptrn/lock_or_not', self::add_to_lock_or_not_results( $post_id, $result) , $post_id, $declined, $user );
 		
 	}
+	
+	public static function populate_patreon_level_select_from_ajax() {
+		// This function accepts the ajax request from the metabox and calls the relevant function to populate the tiers select
+		
+		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
+			return;
+		}
+		
+		// Just bail out if the action is not relevant, just in case
+		if ( $_REQUEST['action'] != 'patreon_wordpress_populate_patreon_level_select' ) {
+			return;
+		}
+		
+		// If post id was not passed, exit with error
+		if ( !isset( $_REQUEST['pw_post_id'] ) OR $_REQUEST['pw_post_id'] == '' ) {
+			echo 'Error: Could not get post id';
+			exit;
+		}
+		
+		$post = get_post( $_REQUEST['pw_post_id'] );
+		
+		echo Patreon_Wordpress::make_tiers_select( $post );
+		exit;
+		
+	}
 	public static function make_tiers_select( $post = false ) {
+		
+		if( !( is_admin() && current_user_can( 'manage_options' ) ) ) {
+			return;
+		}
 		
 		if ( !$post ) {
 			global $post;
@@ -1241,7 +1272,7 @@ class Patreon_Wordpress {
 			
 		}
 		
-		return apply_filters( 'ptrn/post_locking_reward_selection', $select_options, $post );
+		return apply_filters( 'ptrn/post_locking_tier_selection', $select_options, $post );
 	
 	}
 	

--- a/patreon.php
+++ b/patreon.php
@@ -81,6 +81,9 @@ define( "PATREON_TEXT_OVER_BUTTON_9", 'This content is available exclusively to 
 define( "PATREON_TEXT_OVER_BUTTON_10", 'This content is available exclusively to Patreon members pledging $%%pledgelevel%% or more at the time this content was posted, or having at least $%%total_pledge%% pledged in total.' );
 define( "PATREON_TEXT_OVER_BUTTON_11", 'This content is available exclusively to Patreon members pledging $%%pledgelevel%% or more at the time this content was posted.' );
 define( "PATREON_COULDNT_ACQUIRE_USER_DETAILS", 'Sorry. Could not acquire your info from Patreon. Please try again later.' );
+define("PATREON_TEXT_EVERYONE", 'Everyone' );
+define("PATREON_TEXT_ANY_PATRON", 'Any Patron' );
+define("PATREON_TEXT_YOU_HAVE_NO_REWARDS_IN_THIS_CAMPAIGN", 'No rewards found. Set up rewards at Patreon.' );
 
 include 'classes/patreon_wordpress.php';
 


### PR DESCRIPTION
**Problem**

Tier selection for locking posts needed to be added to locking metabox.

**Solution**

Code to pull creator's tiers and populate a select box added to metabox. Existing $ input box moved to advanced and still usable. Tier select metabox just assigns a $ level based on selected tier just like the old $ input box. Old $ input box can override this manually. No changes to locking logic.

Should not affect existing installs.

Creator tier pulling and select box population is triggered via an AJAX request upon document ready and does not slow down or block loading of post editing page. 

Code to save the creator's tier info with names in the local db added for use on locked interface (not for this PR) in frontend. 

**Verification**

![New-Tier-lockbox](https://user-images.githubusercontent.com/13155428/56374216-eb617480-6202-11e9-88b8-dc0c3017546d.jpg)

In working order with this PR. Select box functions in conjunction with old $ input box. Tested. 

**Does this need tests**

Tested, however should be beta'ed before release.
