### PR TITLE
Revamp notices

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -687,7 +687,7 @@ class Patreon_Wordpress {
 			
 			?>
 				 <div class="notice notice-info is-dismissible">
-					<p>Did Patreon WordPress plugin transform your membership business? Help creators like yourself find out about this plugin <a href="https://wordpress.org/support/plugin/patreon-connect/reviews/#new-post" target="_blank">by rating and giving your brutally honest thoughts!</a></p>
+					<p>Did Patreon WordPress help your site? Help creators like yourself find out about it <a href="https://wordpress.org/support/plugin/patreon-connect/reviews/#new-post" target="_blank">by giving us a good rating!</a></p>
 				</div>
 			<?php	
 			

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -681,9 +681,20 @@ class Patreon_Wordpress {
 			
 		}
 		
-		$rate_plugin_notice_shown = get_option('patreon-rate-plugin-notice-shown',false);
+		$rate_plugin_notice_shown = get_option( 'patreon-rate-plugin-notice-shown', false );
+		$plugin_first_installed   = get_option( 'patreon-rate-plugin-first-installed', 0 );
 		
-		if( !$rate_plugin_notice_shown ) {
+		// If plugin first installed date is not present, then this is an old installation. Reset the rate plugin notice shown flag.
+		
+		if ( $plugin_first_installed == 0 ) {
+			$rate_plugin_notice_shown = false;
+			update_option( 'patreon-rate-plugin-first-installed', time() );
+			delete_option( 'patreon-rate-plugin-notice-shown' );
+		}
+		
+		// The below will trigger a rating notice once if it was not shown and the plugin was installed more than 30 days ago.
+		// It will also trigger once for existing installs before this version.
+		if( !$rate_plugin_notice_shown AND ( ( time() - $plugin_first_installed ) > ( 30 * 24 * 3600 ) ) AND $plugin_first_installed > 0 ) {
 			
 			?>
 				 <div class="notice notice-info is-dismissible">

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -694,34 +694,7 @@ class Patreon_Wordpress {
 			update_option( 'patreon-rate-plugin-notice-shown', 1 );
 			
 		}
-		
-		$file_feature_notice_shown = get_option( 'patreon-file-locking-feature-notice-shown', false );
-		
-		if( !$file_feature_notice_shown AND !get_option( 'patreon-enable-file-locking', false ) ) {
 			
-			?>
-				 <div class="notice notice-info is-dismissible">
-				 <h3>The Patreon Wordpress plugin now supports image locking!</h3>
-					<p>If you were using or would like to use image locking feature that Patreon WordPress offers, now you must turn it on in your <a href="<?php echo admin_url('admin.php?page=patreon-plugin'); ?>">plugin settings</a> and visit 'Permalinks' settings of your WordPress site and click 'Save'. Otherwise image locking feature will be disabled or your images may appear broken. <br /><br />Want to learn more about why image locking could be useful for you? <a href="https://www.patreondevelopers.com/t/how-to-use-image-locking-feature-in-patreon-wordpress-plugin/461" target="_blank">Read more about image locking here</a>.</p>
-				</div>
-			<?php	
-			update_option( 'patreon-file-locking-feature-notice-shown', 1 );
-			
-		}
-		
-		if( !get_option( 'patreon-gdpr-notice-shown', false ) ) {
-			
-			?>
-				 <div class="notice notice-info is-dismissible">
-				 <h3>Making your site GDPR compliant with Patreon WordPress</h3>
-					<p>Please visit <a href="<?php echo admin_url('tools.php?wp-privacy-policy-guide=1#wp-privacy-policy-guide-patreon-wordpress'); ?>">the new WordPress privacy policy recommendation page</a> and copy & paste the section related to Patreon WordPress to your privacy policy page.<br><br>You can read our easy tutorial for GDPR compliance with Patreon WordPress <a href="https://patreon.zendesk.com/hc/en-us/articles/360004198011" target="_blank">by visiting our GDPR help page</a></p>
-				</div>
-			<?php	
-			
-			update_option( 'patreon-gdpr-notice-shown', 1 );
-			
-		}
-	
 		if( get_option( 'patreon-wordpress-update-available', false ) ) {
 			
 			?>

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -232,6 +232,7 @@ class Patreon_Wordpress {
 		if ( $plugin_first_activated == 0 ) {
 			// If no date was set, set it to now
 			update_option( 'patreon-plugin-first-activated', time() );
+			update_option( 'patreon-existing-installation', true );
 		}
 		
 	}
@@ -660,7 +661,7 @@ class Patreon_Wordpress {
 			update_option( 'patreon-image-option-transition-done', true );
 			
 		}
-		
+
 	}
 	public static function add_privacy_policy_section() {
 
@@ -671,6 +672,8 @@ class Patreon_Wordpress {
 		
 		// This function processes any admin wide message or notification to display
 		
+		$already_showed_non_system_notice = false;
+			
 		// Wp org wants non-error / non-functionality related notices to be shown infrequently and one per admin-wide page load, and be dismissable permanently. 
 		
 		$mailing_list_notice_shown = get_option( 'patreon-mailing-list-notice-shown', false );
@@ -680,36 +683,32 @@ class Patreon_Wordpress {
 		if( !$mailing_list_notice_shown ) {
 			
 			?>
-				 <div class="notice notice-success is-dismissible  patreon-wordpress">
+				 <div class="notice notice-success is-dismissible  patreon-wordpress" id="patreon-mailing-list-notice-shown">
 					<p>Would you like to receive notices, tips & tricks for Patreon WordPress? <a href="https://patreonforms.typeform.com/to/dPBVp1" target="_blank">Join our mailing list here!</a></p>
 				</div>
 			<?php	
 			
-			// Set the last notice shown date
-			self::set_last_non_system_notice_shown_date();
 			$already_showed_non_system_notice = true;
 			
 		}
-
+		
 		$rate_plugin_notice_shown = get_option( 'patreon-rate-plugin-notice-shown', false );
 		
 		// The below will trigger a rating notice once if it was not shown and the plugin was installed more than 37 days ago.
 		// It will also trigger once for existing installs before this version. Show 30 days after the plugin was first installed, and 7 days after any last notice
 
-		if( !$rate_plugin_notice_shown AND self::check_days_after_last_non_system_notice( 7 ) AND self::calculate_days_after_first_activation( 37 ) ) {
+		if( !$rate_plugin_notice_shown AND self::check_days_after_last_non_system_notice( 7 ) AND self::calculate_days_after_first_activation( 37 ) AND !$already_showed_non_system_notice ) {
 
 			?>
-				 <div class="notice notice-info is-dismissible patreon-wordpress">
+				 <div class="notice notice-info is-dismissible patreon-wordpress" id="patreon-rate-plugin-notice-shown">
 					<p>Did Patreon WordPress help your site? Help creators like yourself find out about it <a href="https://wordpress.org/support/plugin/patreon-connect/reviews/#new-post" target="_blank">by giving us a good rating!</a></p>
 				</div>
 			<?php	
 
-			// Set the last notice shown date
-			self::set_last_non_system_notice_shown_date();
 			$already_showed_non_system_notice = true;
 			
 		}
-		
+
 		// This is a plugin system info notice. 
 		if( get_option( 'patreon-wordpress-app-credentials-success', false ) ) {
 			
@@ -762,7 +761,30 @@ class Patreon_Wordpress {
 		
 		// Mapping what comes from REQUEST to a given value avoids potential security problems
 		if ( $_REQUEST['notice_id'] == 'patreon-wordpress-update-available' ) {
-			delete_option( 'patreon-wordpress-update-available');
+			delete_option( 'patreon-wordpress-update-available' );
+		}
+		
+		// Mapping what comes from REQUEST to a given value avoids potential security problems
+		if ( $_REQUEST['notice_id'] == 'patreon-mailing-list-notice-shown' ) {
+			update_option( 'patreon-mailing-list-notice-shown', true );
+			
+			// Set the last notice shown date
+			self::set_last_non_system_notice_shown_date();
+		}
+		
+		// Mapping what comes from REQUEST to a given value avoids potential security problems
+		if ( $_REQUEST['notice_id'] == 'patreon-rate-plugin-notice-shown' ) {
+			update_option( 'patreon-rate-plugin-notice-shown', true );
+			
+			// Set the last notice shown date
+			self::set_last_non_system_notice_shown_date();
+		}
+		// Mapping what comes from REQUEST to a given value avoids potential security problems
+		if ( $_REQUEST['notice_id'] == 'apatreon-rate-plugin-notice-shown' ) {
+			update_option( 'apatreon-rate-plugin-notice-shown', true );
+			
+			// Set the last notice shown date
+			self::set_last_non_system_notice_shown_date();
 		}
 		
 	}

--- a/patreon.php
+++ b/patreon.php
@@ -84,4 +84,6 @@ define( "PATREON_COULDNT_ACQUIRE_USER_DETAILS", 'Sorry. Could not acquire your i
 
 include 'classes/patreon_wordpress.php';
 
+register_activation_hook( __FILE__, array( 'Patreon_Wordpress', 'activate' ) );
+
 $Patreon_Wordpress = new Patreon_Wordpress;


### PR DESCRIPTION
**Problem***

There is an upcoming rule change at WP org regarding how admin-wide notices from plugins are handled, which affects PW's notices.

https://make.wordpress.org/plugins/2019/05/14/proposal-to-modify-plugin-guidelines/

Additionally we decided to show the notice asking users to rate the plugin 4-5 weeks after the plugin is installed, instead of showing prematurely upon install.  We also wanted to have the capability to show future notices while remaining compatible with the new rules.

We also wanted to reduce notices and remove now unneeded notices like GDPR notice, and the image locking feature notice. 

**Solution**

Notices which have fulfilled their purpose removed. 

Code to save the time at which the plugin was first activated was added. 

Code to save the time at which a non-system notice was shown was added.

Code to detect existing plugin installs was added.

Existing 'join our mailing list' and 'rate our plugin' notices made permanent until dismissed. They are also non-repeating.

'Join our mailing list' notice is shown immediately while rate plugin notice waits 5 weeks. 

System notices like error notices, success notices, functional warnings are exempt from the rule changes in WP org so they are not modified.

For any non-system notice that is not in above classification, added a 7 day wait in between showing the notices. 

This system can be used for future notices and all such notices can be set to show at desired times after the plugin was first installed.

**Verification**

Can be tested by installing this branch on a fresh WP installation, or on an installation which already has the earlier PW versions. Behavior is as follows:

For existing installs, the plugin will not show any notices because all notices already should have been shown long ago.

For new installs, the plugin first shows the 'Join our mailing list' notice. Which stays permanent on all admin page loads (admin wide) until dismissed. When dismissed, the notice never shows again. After 37 days, 'Rate our plugin' notice is shown, and shows admin-wide permanently until dismissed. After dismissal, it never shows again. This behavior is compliant with WP org rules.

**Does this need tests**

No, tested. Will be tested again after 1.2.5 is packaged for release.




