### PR TITLE
Add beta string to api calls

### DIFF
--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -95,7 +95,7 @@ class Patreon_API {
 		
 		$headers = array(
 			'Authorization' => 'Bearer ' . $this->access_token,
-			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
+			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . PATREON_WORDPRESS_BETA_STRING . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
 		);
 		
 		$api_request = array(

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -42,7 +42,7 @@ class Patreon_OAuth {
 		$api_endpoint = "https://api.patreon.com/oauth2/token";
 		
 		$headers = array(
-			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
+			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . PATREON_WORDPRESS_BETA_STRING . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
 		);		
 	
 		$api_request = array(

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -48,6 +48,7 @@ class Patreon_Wordpress {
 
 		add_action( 'wp_head', array( $this, 'updatePatreonUser' ) );
 		add_action( 'init', array( $this, 'checkPatreonCreatorID' ) );
+		add_action( 'init', array( $this, 'check_plugin_activation_date_for_existing_installs' ) );
 		add_action( 'admin_init', array( $this, 'post_credential_update_api_connectivity_check' ) );
 		add_action( 'update_option_patreon-client-id', array( $this, 'toggle_check_api_credentials_on_setting_save' ), 10, 2 );
 		add_action( 'update_option_patreon-client-secret', array( $this, 'toggle_check_api_credentials_on_setting_save' ), 10, 2 );
@@ -219,6 +220,19 @@ class Patreon_Wordpress {
 				
 			}
 			
+		}
+		
+	}
+	public static function check_plugin_activation_date_for_existing_installs() {
+		
+		// Checks if plugin first activation date is saved for existing installs. Its here for backwards compatibility for existing installs before this version (1.2.5), and in case this meta info is lost in the db for any reason
+		
+		$plugin_first_activated = get_option( 'patreon-plugin-first-activated', 0 );
+				
+		if ( $plugin_first_activated == 0 ) {
+			// If no date was set, set it to now
+			update_option( 'patreon-plugin-first-activated', time() );
+			update_option( 'patreon-existing-installation', true );
 		}
 		
 	}
@@ -620,17 +634,8 @@ class Patreon_Wordpress {
 
 			if( $got_updated ) {
 				
-				// Yep, this plugin was updated. Do whatever necessary post-update action:
-				
-				// Flush permalinks (htaccess rules) for Apache servers to make image protection rules active
-				flush_rewrite_rules();
-				
-				// Now remove the flags for regular notifications:
-	
-				delete_option( 'patreon-mailing-list-notice-shown' );
-				delete_option( 'patreon-rate-plugin-notice-shown' );
-				delete_option( 'patreon-file-locking-feature-notice-shown' );
-				
+				// This section is used to do any tasks need doing after plugin updates. Any code changes to this part would take effect not immediately in the same version, but in the next update cycle since WP would use the new code only after plugin has been updated once.
+								
 			}
 
 			
@@ -656,7 +661,7 @@ class Patreon_Wordpress {
 			update_option( 'patreon-image-option-transition-done', true );
 			
 		}
-		
+
 	}
 	public static function add_privacy_policy_section() {
 
@@ -665,86 +670,59 @@ class Patreon_Wordpress {
 	}
 	public static function AdminMessages() {
 		
-		// This function processes any message or notification to display once after updates.
+		// This function processes any admin wide message or notification to display
+		
+		$already_showed_non_system_notice = false;
+			
+		// Wp org wants non-error / non-functionality related notices to be shown infrequently and one per admin-wide page load, and be dismissable permanently. 
 		
 		$mailing_list_notice_shown = get_option( 'patreon-mailing-list-notice-shown', false );
+
+		// Queue this message immediately after activation if not already shown
 		
 		if( !$mailing_list_notice_shown ) {
 			
 			?>
-				 <div class="notice notice-success is-dismissible">
-					<p>Would you like to receive update notices, tips & tricks for Patreon WordPress? <a href="https://patreonforms.typeform.com/to/dPBVp1" target="_blank">Join our mailing list here!</a></p>
+				 <div class="notice notice-success is-dismissible  patreon-wordpress" id="patreon-mailing-list-notice-shown">
+					<p>Would you like to receive notices, tips & tricks for Patreon WordPress? <a href="https://patreonforms.typeform.com/to/dPBVp1" target="_blank">Join our mailing list here!</a></p>
 				</div>
 			<?php	
 			
-			update_option('patreon-mailing-list-notice-shown',1);
+			$already_showed_non_system_notice = true;
 			
 		}
 		
-		$rate_plugin_notice_shown = get_option('patreon-rate-plugin-notice-shown',false);
+		$rate_plugin_notice_shown = get_option( 'patreon-rate-plugin-notice-shown', false );
 		
-		if( !$rate_plugin_notice_shown ) {
-			
+		// The below will trigger a rating notice once if it was not shown and the plugin was installed more than 37 days ago.
+		// It will also trigger once for existing installs before this version. Show 30 days after the plugin was first installed, and 7 days after any last notice
+
+		if( !$rate_plugin_notice_shown AND self::check_days_after_last_non_system_notice( 7 ) AND self::calculate_days_after_first_activation( 37 ) AND !$already_showed_non_system_notice ) {
+
 			?>
-				 <div class="notice notice-info is-dismissible">
-					<p>Did Patreon WordPress plugin transform your membership business? Help creators like yourself find out about this plugin <a href="https://wordpress.org/support/plugin/patreon-connect/reviews/#new-post" target="_blank">by rating and giving your brutally honest thoughts!</a></p>
+				 <div class="notice notice-info is-dismissible patreon-wordpress" id="patreon-rate-plugin-notice-shown">
+					<p>Did Patreon WordPress help your site? Help creators like yourself find out about it <a href="https://wordpress.org/support/plugin/patreon-connect/reviews/#new-post" target="_blank">by giving us a good rating!</a></p>
 				</div>
 			<?php	
-			
-			update_option( 'patreon-rate-plugin-notice-shown', 1 );
-			
-		}
-		
-		$file_feature_notice_shown = get_option( 'patreon-file-locking-feature-notice-shown', false );
-		
-		if( !$file_feature_notice_shown AND !get_option( 'patreon-enable-file-locking', false ) ) {
-			
-			?>
-				 <div class="notice notice-info is-dismissible">
-				 <h3>The Patreon Wordpress plugin now supports image locking!</h3>
-					<p>If you were using or would like to use image locking feature that Patreon WordPress offers, now you must turn it on in your <a href="<?php echo admin_url('admin.php?page=patreon-plugin'); ?>">plugin settings</a> and visit 'Permalinks' settings of your WordPress site and click 'Save'. Otherwise image locking feature will be disabled or your images may appear broken. <br /><br />Want to learn more about why image locking could be useful for you? <a href="https://www.patreondevelopers.com/t/how-to-use-image-locking-feature-in-patreon-wordpress-plugin/461" target="_blank">Read more about image locking here</a>.</p>
-				</div>
-			<?php	
-			update_option( 'patreon-file-locking-feature-notice-shown', 1 );
+
+			$already_showed_non_system_notice = true;
 			
 		}
-		
-		if( !get_option( 'patreon-gdpr-notice-shown', false ) ) {
-			
-			?>
-				 <div class="notice notice-info is-dismissible">
-				 <h3>Making your site GDPR compliant with Patreon WordPress</h3>
-					<p>Please visit <a href="<?php echo admin_url('tools.php?wp-privacy-policy-guide=1#wp-privacy-policy-guide-patreon-wordpress'); ?>">the new WordPress privacy policy recommendation page</a> and copy & paste the section related to Patreon WordPress to your privacy policy page.<br><br>You can read our easy tutorial for GDPR compliance with Patreon WordPress <a href="https://patreon.zendesk.com/hc/en-us/articles/360004198011" target="_blank">by visiting our GDPR help page</a></p>
-				</div>
-			<?php	
-			
-			update_option( 'patreon-gdpr-notice-shown', 1 );
-			
-		}
-	
-		if( get_option( 'patreon-wordpress-update-available', false ) ) {
-			
-			?>
-				 <div class="notice notice-info is-dismissible patreon-wordpress" id="patreon-wordpress-update-available">
-				 <h3>New version of Patreon WordPress is available</h3>
-					<p>To be able to receive the latest features, security and bug fixes, please update your plugin by <a href="<?php echo wp_nonce_url( get_admin_url() . 'update.php?action=upgrade-plugin&plugin=' . PATREON_WORDPRESS_PLUGIN_SLUG,'upgrade-plugin_' . PATREON_WORDPRESS_PLUGIN_SLUG ); ?>">clicking here</a>.</p>
-				</div>
-			<?php
-			
-		}
-		
+
+		// This is a plugin system info notice. 
 		if( get_option( 'patreon-wordpress-app-credentials-success', false ) ) {
 			
 			?>
 				 <div class="notice notice-success is-dismissible patreon-wordpress" id="patreon-wordpress-update-available">
 				 <h3>Your Patreon client details were successfully saved!</h3>
-					<p>Patreon WordPress is now ready to go and your site is connected to Patreon! You can now lock any content by using the "Patreon Level" meta box in your post editor!</p>
+					<p>Patreon WordPress is now ready to go and your site is connected to Patreon! You can now lock any post by using the "Patreon Level" meta box in your post editor!</p>
 				</div>
 			<?php
-			
+
 			delete_option( 'patreon-wordpress-app-credentials-success' );
 		}
 		
+		// This is a plugin system info notice. 
 		if( get_option( 'patreon-wordpress-app-credentials-failure', false ) ) {
 			
 			?>
@@ -755,6 +733,7 @@ class Patreon_Wordpress {
 			<?php
 			
 			delete_option( 'patreon-wordpress-app-credentials-failure' );
+			
 		}
 		
 	}
@@ -782,9 +761,32 @@ class Patreon_Wordpress {
 		
 		// Mapping what comes from REQUEST to a given value avoids potential security problems
 		if ( $_REQUEST['notice_id'] == 'patreon-wordpress-update-available' ) {
-			delete_option( 'patreon-wordpress-update-available');
+			delete_option( 'patreon-wordpress-update-available' );
 		}
-
+		
+		// Mapping what comes from REQUEST to a given value avoids potential security problems
+		if ( $_REQUEST['notice_id'] == 'patreon-mailing-list-notice-shown' ) {
+			update_option( 'patreon-mailing-list-notice-shown', true );
+			
+			// Set the last notice shown date
+			self::set_last_non_system_notice_shown_date();
+		}
+		
+		// Mapping what comes from REQUEST to a given value avoids potential security problems
+		if ( $_REQUEST['notice_id'] == 'patreon-rate-plugin-notice-shown' ) {
+			update_option( 'patreon-rate-plugin-notice-shown', true );
+			
+			// Set the last notice shown date
+			self::set_last_non_system_notice_shown_date();
+		}
+		// Mapping what comes from REQUEST to a given value avoids potential security problems
+		if ( $_REQUEST['notice_id'] == 'apatreon-rate-plugin-notice-shown' ) {
+			update_option( 'apatreon-rate-plugin-notice-shown', true );
+			
+			// Set the last notice shown date
+			self::set_last_non_system_notice_shown_date();
+		}
+		
 	}
 	public function toggle_check_api_credentials_on_setting_save(  $old_value, $new_value ) {
 		
@@ -839,7 +841,7 @@ class Patreon_Wordpress {
 			$creator_access = true;
 			
 		}
-		
+
 		// Try to do a creator's token refresh
 	
 		if ( $tokens = self::refresh_creator_access_token() ) {
@@ -1148,6 +1150,55 @@ class Patreon_Wordpress {
 		
 		return apply_filters( 'ptrn/lock_or_not', self::add_to_lock_or_not_results( $post_id, $result) , $post_id, $declined, $user );
 		
+	}
+	public function activate() {
+		
+		// This function kicks in after the plugin is activated. Used to perform tasks which need to be run during plugin activation
+		
+		// Checking if $plugin_first_activated value exists prevents resetting of this value on every plugin deactivation/activation
+
+		$plugin_first_activated   = get_option( 'patreon-plugin-first-activated', 0 );
+				
+		if ( $plugin_first_activated == 0 ) {
+			update_option( 'patreon-plugin-first-activated', time() );
+		}
+		
+	}
+	public static function check_days_after_last_non_system_notice( $days ) {
+		// Calculates if $days many days passed after last non system notice was showed. Used in deciding if and when to show admin wide notices
+		
+		$last_non_system_notice_shown_date = get_option( 'patreon-last-non-system-notice-shown-date', 0 );
+		
+		// Calculate if $days days passed since last notice was shown		
+		if ( ( time() - $last_non_system_notice_shown_date ) > ( $days * 24 * 3600 ) ) {
+			// More than $days days. Set flag
+			return true;
+		}
+		
+		return false;
+		
+	}
+	public static function calculate_days_after_first_activation( $days ) {
+		
+		// Used to calculate days passed after first plugin activation. 
+		
+		$plugin_first_activated   = get_option( 'patreon-plugin-first-activated', 0 );
+				
+		// Calculate if $days days passed since last notice was shown		
+		if ( ( time() - $plugin_first_activated ) > ( $days * 24 * 3600 ) ) {
+			// More than $days days. Set flag
+			return true;
+		}
+
+		return false;
+			
+	}
+	public static function set_last_non_system_notice_shown_date() {
+		
+		// Sets the last non system notice shown date to now whenever called. Used for decicing when to show admin wide notices that are not related to functionality. 
+		
+		update_option( 'patreon-last-non-system-notice-shown-date', time() );
+			
 	}
 	
 }

--- a/patreon.php
+++ b/patreon.php
@@ -85,4 +85,6 @@ define( "PATREON_COULDNT_ACQUIRE_USER_DETAILS", 'Sorry. Could not acquire your i
 
 include 'classes/patreon_wordpress.php';
 
+register_activation_hook( __FILE__, array( 'Patreon_Wordpress', 'activate' ) );
+
 $Patreon_Wordpress = new Patreon_Wordpress;

--- a/patreon.php
+++ b/patreon.php
@@ -60,6 +60,7 @@ define( "PATREON_CREATOR_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons 
 define( "PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST", 'Post is already public. If you would like to lock this post, please set a pledge level for it' );
 define( "PATREON_NO_POST_ID_TO_UNLOCK_POST", 'Sorry - could not get the post id for this locked post' );
 define( "PATREON_WORDPRESS_VERSION", '1.2.4' );
+define( "PATREON_WORDPRESS_BETA_STRING", '' );
 define( "PATREON_WORDPRESS_PLUGIN_SLUG", plugin_basename( __FILE__ ) );
 define( "PATREON_PRIVACY_POLICY_ADDENDUM", '<h2>Patreon features in this website</h2>In order to enable you to use this website with Patreon services, we save certain functionally important Patreon information about you in this website if you log in with Patreon.
 <br /><br />


### PR DESCRIPTION
**Problem**

When we issue betas in the forum, we are not able to detect how many people are using the beta from the user agent string that is included in the calls to the api. We want to be able to detect beta users.

**Solution**

Added an extra text define to be used as an addition to the user string which is used in calls to the api. This string will be able to take in the value of any sub version or feature (ie like "1.2.5 beta", or "tier based locking feature") and it will allow us to even have more than one beta out with different features and detect their usage.

When issuing an actual release, beta text define will be empty.

**Verification**

Can be tested by getting installed into any fresh WP install. 

**Does this need tests**

No, tested.