### PR TITLE
capital_P_dangit ;)

### DIFF
--- a/classes/patreon_api.php
+++ b/classes/patreon_api.php
@@ -108,7 +108,7 @@ class Patreon_API {
 		
 		$headers = array(
 			'Authorization' => 'Bearer ' . $this->access_token,
-			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . PATREON_WORDPRESS_BETA_STRING . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
+			'User-Agent' => 'Patreon-WordPress, version ' . PATREON_WORDPRESS_VERSION . PATREON_WORDPRESS_BETA_STRING . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
 		);
 		
 		$api_request = array(

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -183,11 +183,11 @@ class Patreon_Frontend {
 
 		$label                    = PATREON_TEXT_OVER_BUTTON_1;
 		$user_logged_into_patreon = self::isUserLoggedInPatreon();
-		$is_patron                = Patreon_Wordpress::isPatron( wp_get_current_user() );
+		$is_patron                = Patreon_WordPress::isPatron( wp_get_current_user() );
 		$messages                 = self::processPatreonMessages();
 		$user                     = wp_get_current_user();
-		$declined                 = Patreon_Wordpress::checkDeclinedPatronage( $user );		
-		$user_patronage           = Patreon_Wordpress::getUserPatronage();						
+		$declined                 = Patreon_WordPress::checkDeclinedPatronage( $user );		
+		$user_patronage           = Patreon_WordPress::getUserPatronage();						
 			
 		// Get creator full name:
 		$creator_full_name = get_option( 'patreon-creator-full-name', false );
@@ -200,10 +200,10 @@ class Patreon_Frontend {
 		if ( !isset( $args['lock'] ) ) {
 			
 			if ( isset( $args['post_id'] ) ) {
-				$lock_or_not = Patreon_Wordpress::lock_or_not( $args['post_id'] );
+				$lock_or_not = Patreon_WordPress::lock_or_not( $args['post_id'] );
 			}
 			else {
-				$lock_or_not = Patreon_Wordpress::lock_or_not();
+				$lock_or_not = Patreon_WordPress::lock_or_not();
 			}
 		}
 		
@@ -374,11 +374,11 @@ class Patreon_Frontend {
 
 		$label                    = '';
 		$user_logged_into_patreon = self::isUserLoggedInPatreon();
-		$is_patron                = Patreon_Wordpress::isPatron( wp_get_current_user() );
+		$is_patron                = Patreon_WordPress::isPatron( wp_get_current_user() );
 		$messages                 = self::processPatreonMessages();
 		$user                     = wp_get_current_user();
-		$declined                 = Patreon_Wordpress::checkDeclinedPatronage( $user );		
-		$user_patronage           = Patreon_Wordpress::getUserPatronage();						
+		$declined                 = Patreon_WordPress::checkDeclinedPatronage( $user );		
+		$user_patronage           = Patreon_WordPress::getUserPatronage();						
 			
 		// Get creator full name:
 		$creator_full_name = get_option( 'patreon-creator-full-name', false );
@@ -391,10 +391,10 @@ class Patreon_Frontend {
 		if ( !isset( $args['lock'] ) ) {
 			
 			if ( isset( $args['post_id'] ) ) {
-				$lock_or_not = Patreon_Wordpress::lock_or_not( $args['post_id'] );
+				$lock_or_not = Patreon_WordPress::lock_or_not( $args['post_id'] );
 			}
 			else {
-				$lock_or_not = Patreon_Wordpress::lock_or_not();
+				$lock_or_not = Patreon_WordPress::lock_or_not();
 			}
 		}
 		
@@ -668,7 +668,7 @@ class Patreon_Frontend {
 		
 		$label                    = apply_filters( 'ptrn/universal_button_label', PATREON_TEXT_UNLOCK_WITH_PATREON );
 		$user_logged_into_patreon = self::isUserLoggedInPatreon();
-		$is_patron                = Patreon_Wordpress::isPatron();
+		$is_patron                = Patreon_WordPress::isPatron();
 		
 		// Change this after getting info about which value confirms user's payment is declined. The only different button label is for that condition.
 		
@@ -692,7 +692,7 @@ class Patreon_Frontend {
 			if ( $user ) {
 				
 				// REVISIT - whats below may be a concern - it connects to API to check for valid user for every generation of button. If we could cache it it would be better
-				$user_response = Patreon_Wordpress::getPatreonUser( $user );
+				$user_response = Patreon_WordPress::getPatreonUser( $user );
 
 				if ( $user_response ) {
 					// This is a user logged into Patreon. 
@@ -772,7 +772,7 @@ class Patreon_Frontend {
 
 			if ( $user ) {
 				
-				$user_response = Patreon_Wordpress::getPatreonUser( $user );
+				$user_response = Patreon_WordPress::getPatreonUser( $user );
 				// ^ REVISIT - whats above may be a concern - it connects to API to check for valid user for every generation of button. If we could cache it it would be better
 
 				if ( $user_response ) {
@@ -857,10 +857,10 @@ class Patreon_Frontend {
 			}
 			 
 			$user                           = wp_get_current_user();
-			$user_pledge_relationship_start = Patreon_Wordpress::get_user_pledge_relationship_start();
-			$user_patronage                 = Patreon_Wordpress::getUserPatronage();
-			$user_lifetime_patronage        = Patreon_Wordpress::get_user_lifetime_patronage();
-			$declined                       = Patreon_Wordpress::checkDeclinedPatronage($user);
+			$user_pledge_relationship_start = Patreon_WordPress::get_user_pledge_relationship_start();
+			$user_patronage                 = Patreon_WordPress::getUserPatronage();
+			$user_lifetime_patronage        = Patreon_WordPress::get_user_lifetime_patronage();
+			$declined                       = Patreon_WordPress::checkDeclinedPatronage($user);
 
 			// Check if post was set for active patrons only
 			$patreon_active_patrons_only = get_post_meta( $post->ID, 'patreon-active-patrons-only', true );
@@ -957,7 +957,7 @@ class Patreon_Frontend {
 		
 		// Now send the post id to locking decision function 
 		
-		$lock_or_not = Patreon_Wordpress::lock_or_not($post_id);
+		$lock_or_not = Patreon_WordPress::lock_or_not($post_id);
 		
 		// An array with args should be returned
 		$hide_content = false;
@@ -1024,11 +1024,11 @@ class Patreon_Frontend {
 		
 		$label                    = PATREON_VALID_PATRON_POST_FOOTER_TEXT;
 		$user_logged_into_patreon = self::isUserLoggedInPatreon();
-		$is_patron                = Patreon_Wordpress::isPatron( wp_get_current_user() );
+		$is_patron                = Patreon_WordPress::isPatron( wp_get_current_user() );
 		$messages                 = self::processPatreonMessages();
 		$user                     = wp_get_current_user();
-		$declined                 = Patreon_Wordpress::checkDeclinedPatronage( $user );		
-		$user_patronage           = Patreon_Wordpress::getUserPatronage();						
+		$declined                 = Patreon_WordPress::checkDeclinedPatronage( $user );		
+		$user_patronage           = Patreon_WordPress::getUserPatronage();						
 			
 		// Get creator full name:
 		$creator_full_name = get_option( 'patreon-creator-full-name', false );
@@ -1041,10 +1041,10 @@ class Patreon_Frontend {
 		if ( !isset( $args['lock'] ) ) {
 			
 			if ( isset( $args['post_id'] ) ) {
-				$lock_or_not = Patreon_Wordpress::lock_or_not( $args['post_id'] );
+				$lock_or_not = Patreon_WordPress::lock_or_not( $args['post_id'] );
 			}
 			else {
-				$lock_or_not = Patreon_Wordpress::lock_or_not();
+				$lock_or_not = Patreon_WordPress::lock_or_not();
 			}
 		}
 		

--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -183,7 +183,7 @@ class Patreon_Login {
 
 				} else {
 
-					/* log user into existing wordpress account with matching username */
+					/* log user into existing WordPress account with matching username */
 					wp_set_current_user( $user->ID, $user->user_login );
 					wp_set_auth_cookie( $user->ID );
 					do_action( 'wp_login', $user->user_login, $user );
@@ -248,7 +248,7 @@ class Patreon_Login {
 
 		if ( $user == false ) {
 
-			/* create wordpress user with provided username */
+			/* create WordPress user with provided username */
 			
 			$random_password = wp_generate_password( 64, false );
 			$user_email 	 = '';
@@ -327,7 +327,7 @@ class Patreon_Login {
 
 			} else {
 				
-				/* wordpress account creation failed */
+				/* WordPress account creation failed */
 				
 				$redirect = add_query_arg( 'patreon_message', 'patreon_could_not_create_wp_account', $redirect );
 				wp_redirect( $redirect );

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -42,7 +42,7 @@ class Patreon_OAuth {
 		$api_endpoint = "https://api.patreon.com/oauth2/token";
 		
 		$headers = array(
-			'User-Agent' => 'Patreon-Wordpress, version ' . PATREON_WORDPRESS_VERSION . PATREON_WORDPRESS_BETA_STRING . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
+			'User-Agent' => 'Patreon-WordPress, version ' . PATREON_WORDPRESS_VERSION . PATREON_WORDPRESS_BETA_STRING . ', platform ' . php_uname('s') . '-' . php_uname( 'r' ),
 		);		
 	
 		$api_request = array(

--- a/classes/patreon_options.php
+++ b/classes/patreon_options.php
@@ -72,7 +72,7 @@ class Patreon_Options {
         <div class="wrap">
 
             <div id="icon-options-general" class="icon32"></div>
-			<h1>Patreon Wordpress Settings</h1>
+			<h1>Patreon WordPress Settings</h1>
 
             <div id="poststuff">
 
@@ -141,7 +141,7 @@ class Patreon_Options {
                                 <div class="handlediv" title="Click to toggle"><br /></div>
                                 <!-- Toggle -->
 
-                                <h2 class="handle"><span>Patreon Wordpress Options</span></h2>
+                                <h2 class="handle"><span>Patreon WordPress Options</span></h2>
 
                                 <div class="inside">
 
@@ -243,13 +243,13 @@ class Patreon_Options {
                                 <div class="handlediv" title="Click to toggle"><br></div>
                                 <!-- Toggle -->
 
-                                <h2 class="hndle">About Patreon Wordpress</h2>
+                                <h2 class="hndle">About Patreon WordPress</h2>
 
                                <div class="inside">
-									<p>Patreon Wordpress developed by Patreon</p>
+									<p>Patreon WordPress developed by Patreon</p>
 
                                     <p><strong>SUPPORT &amp; TECHNICAL HELP</strong> <br>
-                                    We actively support this plugin on our <a href="https://www.patreondevelopers.com/c/patreon-wordpress-plugin-support" target="_blank">Patreon Wordpress Support Forum</a>.</p>
+                                    We actively support this plugin on our <a href="https://www.patreondevelopers.com/c/patreon-wordpress-plugin-support" target="_blank">Patreon WordPress Support Forum</a>.</p>
                                     <p><strong>DOCUMENTATION</strong> <br>Technical documentation and code examples available @ <a href="https://patreon.com/apps/wordpress" target="_blank">https://patreon.com/apps/wordpress</a></p>
                                 </div>
 								<!-- .inside -->

--- a/classes/patreon_protect.php
+++ b/classes/patreon_protect.php
@@ -225,11 +225,11 @@ class Patreon_Protect {
 		
 		// We are here, then we have a nonzero pledge level. Protect the image.
 		
-		$user_patronage = Patreon_Wordpress::getUserPatronage();
+		$user_patronage = Patreon_WordPress::getUserPatronage();
 
 		$user = wp_get_current_user();
 		
-		$declined = Patreon_Wordpress::checkDeclinedPatronage( $user );
+		$declined = Patreon_WordPress::checkDeclinedPatronage( $user );
 			
 		if ($user_patronage == false 
 			|| $user_patronage < ( $patreon_level * 100 )
@@ -833,9 +833,9 @@ RewriteRule ^" . $upload_dir . "/(.*)$ index.php?patreon_action=serve_patron_onl
 			return 0;
 		}		
 		
-		$declined_patron = Patreon_Wordpress::checkDeclinedPatronage($user);
+		$declined_patron = Patreon_WordPress::checkDeclinedPatronage($user);
 
-		$patron_pledge = Patreon_Wordpress::getUserPatronage();
+		$patron_pledge = Patreon_WordPress::getUserPatronage();
 		
 		$patreon_level = get_post_meta( $attachment_id, 'patreon_level', true );
 		

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -5,7 +5,7 @@ if ( !defined( 'WPINC' ) ) {
 	die;
 }
 
-class Patreon_Wordpress {
+class Patreon_WordPress {
 
 	private static $Patreon_Routing;
 	private static $Patreon_Frontend;
@@ -61,7 +61,7 @@ class Patreon_Wordpress {
 		add_action( 'init', array( $this, 'checkPatreonCreatorName' ) );
 		add_action( 'init', 'Patreon_Login::checkTokenExpiration' );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueueAdminScripts' ) );
-		add_action( 'upgrader_process_complete', 'Patreon_Wordpress::AfterUpdateActions', 10, 2 );
+		add_action( 'upgrader_process_complete', 'Patreon_WordPress::AfterUpdateActions', 10, 2 );
 		add_action( 'admin_notices', array( $this, 'AdminMessages' ) );
 		add_action( 'init', array( $this, 'transitionalImageOptionCheck' ) );
 		add_action( 'admin_init', array( $this, 'add_privacy_policy_section' ), 20 ) ;
@@ -164,7 +164,7 @@ class Patreon_Wordpress {
 			// Set the update time
 			update_user_meta( $user->ID, 'patreon_user_details_last_updated', time() );
 			
-			/* all the details you want to update on wordpress user account */
+			/* all the details you want to update on WordPress user account */
 			update_user_meta( $user->ID, 'patreon_user', $user_response['data']['attributes']['vanity'] );
 			update_user_meta( $user->ID, 'patreon_created', $user_response['data']['attributes']['created'] );
 			update_user_meta( $user->ID, 'user_firstname', $user_response['data']['attributes']['first_name'] );
@@ -994,11 +994,11 @@ class Patreon_Wordpress {
 		}
 
 		$user                           = wp_get_current_user();
-		$user_pledge_relationship_start = Patreon_Wordpress::get_user_pledge_relationship_start( $user );
-		$user_patronage                 = Patreon_Wordpress::getUserPatronage( $user );
-		$is_patron                      = Patreon_Wordpress::isPatron( $user );
-		$user_lifetime_patronage        = Patreon_Wordpress::get_user_lifetime_patronage( $user );
-		$declined                       = Patreon_Wordpress::checkDeclinedPatronage( $user );
+		$user_pledge_relationship_start = Patreon_WordPress::get_user_pledge_relationship_start( $user );
+		$user_patronage                 = Patreon_WordPress::getUserPatronage( $user );
+		$is_patron                      = Patreon_WordPress::isPatron( $user );
+		$user_lifetime_patronage        = Patreon_WordPress::get_user_lifetime_patronage( $user );
+		$declined                       = Patreon_WordPress::checkDeclinedPatronage( $user );
 		$active_patron_at_post_date     = false;
 		
 		// Just bail out if this is not the main query for content and no post id was given
@@ -1288,7 +1288,7 @@ class Patreon_Wordpress {
 		
 		$post = get_post( $_REQUEST['pw_post_id'] );
 				
-		echo Patreon_Wordpress::make_tiers_select( $post );
+		echo Patreon_WordPress::make_tiers_select( $post );
 		exit;
 		
 	}
@@ -1428,3 +1428,9 @@ class Patreon_Wordpress {
 	}
 	
 }
+
+
+/**
+ * Backwards compatibility
+**/
+class_alias('Patreon_WordPress','Patreon_Wordpress');

--- a/patreon.php
+++ b/patreon.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-Plugin Name: Patreon Wordpress
+Plugin Name: Patreon WordPress
 Plugin URI: https://www.patreon.com/apps/wordpress
 Description: Patron-only content, directly on your website.
 Version: 1.2.6
@@ -45,7 +45,7 @@ define( "PATREON_TEXT_UNDER_BUTTON_1", '' );
 define( "PATREON_TEXT_UNDER_BUTTON_2", 'Already a Patreon member? <a href="%%flow_link%%" rel="nofollow">Refresh</a> to access this post.' );
 define( "PATREON_TEXT_UNDER_BUTTON_3", 'Already updated? <a href="%%flow_link%%" rel="nofollow">Refresh</a> to access this post.' );
 define( "PATREON_CANT_LOGIN_STRICT_OAUTH", 'Sorry, couldn\'t log you in with Patreon because you have to be logged in to '.get_bloginfo('NAME').' first' );
-define( "PATREON_LOGIN_WITH_WORDPRESS_NOW", 'You can now login with your wordpress username/password.' );
+define( "PATREON_LOGIN_WITH_WORDPRESS_NOW", 'You can now login with your WordPress username/password.' );
 define( "PATREON_CANT_LOGIN_NONCES_DONT_MATCH", 'Sorry. Aborted Patreon login for security because security cookies dont match.' );
 define( "PATREON_CANT_LOGIN_DUE_TO_API_ERROR", 'Sorry. Login aborted due to an API error.' );
 define( "PATREON_CANT_LOGIN_DUE_TO_API_ERROR_CHECK_CREDENTIALS", 'Sorry. Login aborted due to an API error. Please check API credentials.' );
@@ -84,9 +84,10 @@ define( "PATREON_TEXT_OVER_BUTTON_11", 'This content is available exclusively to
 define( "PATREON_COULDNT_ACQUIRE_USER_DETAILS", 'Sorry. Could not acquire your info from Patreon. Please try again later.' );
 define( "PATREON_TEXT_EVERYONE", 'Everyone' );
 define( "PATREON_TEXT_ANY_PATRON", 'Any patron' );
+define( 'PATREON_TEXT_YOU_HAVE_NO_REWARDS_IN_THIS_CAMPAIGN', '' );
 
 include 'classes/patreon_wordpress.php';
 
-register_activation_hook( __FILE__, array( 'Patreon_Wordpress', 'activate' ) );
+register_activation_hook( __FILE__, array( 'Patreon_WordPress', 'activate' ) );
 
-$Patreon_Wordpress = new Patreon_Wordpress;
+$Patreon_WordPress = new Patreon_WordPress;


### PR DESCRIPTION
Classname changes from Patreon_WordPress (with Patreon_Wordpress as an alias for backwards compatibility) and overall Wordpress / wordpress to WordPress changes.

Also added defining the constant PATREON_TEXT_YOU_HAVE_NO_REWARDS_IN_THIS_CAMPAIGN, since it wasn't defined yet (and triggering a warning because of it).