### PR TITLE
1.8.5 release

### DIFF
--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -128,6 +128,9 @@ class Patreon_Login {
 			
 			do_action( 'patreon_action_after_wp_logged_user_is_updated', $filter_args );
 			
+			// Save this time when patron returned from a Patreon flow to use for deciding when to call the api in unlock actions
+			update_user_meta( $user->ID, 'patreon_user_last_returned_from_any_flow', time() );
+			
 			wp_redirect( $redirect );
 			exit;
 						
@@ -210,7 +213,11 @@ class Patreon_Login {
 						'tokens' => $tokens,
 					);
 					
-					do_action( 'patreon_do_action_after_user_logged_in_via_patreon', $filter_args );					
+					do_action( 'patreon_do_action_after_user_logged_in_via_patreon', $filter_args );
+					
+
+					// Save this time when patron returned from a Patreon flow to use for deciding when to call the api in unlock actions
+					update_user_meta( $user->ID, 'patreon_user_last_returned_from_any_flow', time() );
 						
 					wp_redirect( $redirect );
 					exit;
@@ -329,7 +336,10 @@ class Patreon_Login {
 					'tokens' => $tokens,
 				);
 				
-				do_action( 'patreon_do_action_after_new_user_created_from_patreon_logged_in', $filter_args );				
+				do_action( 'patreon_do_action_after_new_user_created_from_patreon_logged_in', $filter_args );
+				
+				// Save this time when patron returned from a Patreon flow to use for deciding when to call the api in unlock actions
+				update_user_meta( $user->ID, 'patreon_user_last_returned_from_any_flow', time() );
 
 				wp_redirect( $redirect );
 				exit;	
@@ -366,6 +376,10 @@ class Patreon_Login {
 				
 				do_action( 'patreon_do_action_after_existing_user_from_patreon_logged_in', $filter_args );				
 
+				// Save this time when patron returned from a Patreon flow to use for deciding when to call the api in unlock actions
+				update_user_meta( $user->ID, 'patreon_user_last_returned_from_any_flow', time() );
+
+				
 				wp_redirect( $redirect );
 				exit;
 				


### PR DESCRIPTION
- Modified lock or not filter to feed more variables to functions. 
- Added and calculated relevant variables during unlock process
- Added a check for the timestamp of saved patron info
- Now uses the saved patron info if the timestamp is within 2 seconds of current Unix time and does not call the API
- Now saves the timestamp of the time when a user has returned from any Patreon flow
- getPatreonUser now checks for that timestamp in order to decide whether to call the api or not