### PR TITLE
1 8 6 release

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -1758,7 +1758,7 @@ class Patreon_Wordpress {
 			'parent_client_id'      =>  PATREON_PLUGIN_CLIENT_ID,
 		);
 		
-		return $app_info;
+		return apply_filters( 'ptrn/filter_collect_app_info_result', $app_info );
 	}
 
 	public static function check_setup() {

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -18,10 +18,11 @@ class Patreon_Wordpress {
 	public static $patreon_user_profiles;
 	public static $patreon_admin_pointers;
 	public static $patreon_content_sync;
-	public static $current_user_pledge_amount = -1;
+	public static $current_user_pledge_amount =  -1;
 	public static $current_user_patronage_declined = -1;
 	public static $current_user_is_patron = -1;
 	public static $patreon_user_info_cache = array();
+	public static $patreon_pledge_info_cache = array();
 	public static $current_member_details = -1;
 	public static $current_user_patronage_duration = -1;
 	public static $current_user_lifetime_patronage = -1;
@@ -562,20 +563,32 @@ class Patreon_Wordpress {
 		
 	}
 	public static function getUserPatronage( $user = false ) {
+	
+		$using_current_user = false;
 		
-		if ( self::$current_user_pledge_amount != -1 ) {
-			return self::$current_user_pledge_amount;
-		}
-
 		// If user is not given, try to get the current user attribute ID will be 0 if there is no logged in user
 		if ( $user == false ) {
+			$using_current_user = true;
 			$user = wp_get_current_user();
 		}
+
 		// If still no user object, return false
 		if ( $user->ID == 0 ) {
 			return false;
 		}
+		
+		// Compatibility - use the old current_user_pledge_amount_static if user is not given and we are using the current user
+		if ( $using_current_user ) {
+			
+			if ( self::$current_user_pledge_amount != -1 ) {
+				return self::$current_user_pledge_amount;
+			}
+		}
 
+		if ( isset( self::$patreon_pledge_info_cache[$user->ID] ) ) {
+			return self::$patreon_pledge_info_cache[$user->ID];
+		}
+		
 		$creator_id = get_option( 'patreon-creator-id', false );
 
 		if ( $creator_id == false ) {
@@ -610,7 +623,17 @@ class Patreon_Wordpress {
 		}
 		
 		if ( $pledge != false ) {
-			return self::getUserPatronageLevel( $pledge );
+			
+			$pledge_level = self::getUserPatronageLevel( $pledge );
+			
+			// Compatibility - use the old current_user_pledge_amount_static if user is not given and we are using the current user
+			if ( $using_current_user ) {
+				self::$current_user_pledge_amount = $pledge_level;
+			}
+			
+			Patreon_Wordpress::add_to_patreon_pledge_info_cache( $user->ID, $pledge_level );
+			
+			return $pledge_level;
 		}
 
 		return false;
@@ -723,17 +746,13 @@ class Patreon_Wordpress {
 		}
 	}
 	public static function getUserPatronageLevel( $pledge ) {
-		
-		if ( self::$current_user_pledge_amount != -1 ) {
-			return self::$current_user_pledge_amount;
-		}
-		
+				
 		// Exception - for lite tier creators, use currently_entitled_amount_cents until there is a better way to match custom $ without tiers to local info:
 		
 		if ( get_option( 'patreon-creator-has-tiers', 'yes' ) == 'no' ) {
 		
 			if( isset( $pledge['attributes']['amount_cents'] ) ) {
-				return self::$current_user_pledge_amount = $pledge['attributes']['amount_cents'];
+				return $pledge['attributes']['amount_cents'];
 			}
 			// Catch all from old function format
 			return 0;
@@ -802,7 +821,7 @@ class Patreon_Wordpress {
 			}
 		}
 	
-		return self::$current_user_pledge_amount = $max_entitled_tier_value;
+		return $max_entitled_tier_value;
 		
 	}
 	public static function isPatron( $user = false ) {
@@ -2750,6 +2769,21 @@ class Patreon_Wordpress {
 		return self::$patreon_user_info_cache[$user_id] = $user_info;
 		
 	}	
+	public static function add_to_patreon_pledge_info_cache( $user_id, $pledge ) {
+		
+		// This function manages the array that is used as the cache for info of Patreon users in a given page run. What it does is to accept the id of the WP user and a given Patreon user info, then add it to the a cache array 
+		
+		// If the cache array is larger than 50, snip the first item. This may be increased in future
+		
+		if ( !empty( self::$patreon_pledge_info_cache ) && (count( self::$patreon_pledge_info_cache ) > 50)  ) {
+			array_shift( self::$patreon_pledge_info_cache );
+		}
+		
+		// Add the new request and return it
+		
+		return self::$patreon_pledge_info_cache[$user_id] = $pledge;
+		
+    } 
 		
 	public function make_taxonomy_select( $selected_post_type = 'post', $selected_taxonomy = 'category' ) {
 		

--- a/patreon.php
+++ b/patreon.php
@@ -4,7 +4,7 @@
 Plugin Name: Patreon Wordpress
 Plugin URI: https://www.patreon.com/apps/wordpress
 Description: Patron-only content, directly on your website.
-Version: 1.8.5
+Version: 1.8.6
 Author: Patreon <platform@patreon.com>
 Author URI: https://patreon.com
 */
@@ -68,7 +68,7 @@ define( "PATREON_ADMIN_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons on
 define( "PATREON_CREATOR_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons only, it\'s not locked for you because you are logged in as the Patreon creator' );
 define( "PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST", 'Post is already public. If you would like to lock this post, please set a pledge level for it' );
 define( "PATREON_NO_POST_ID_TO_UNLOCK_POST", 'Sorry - could not get the post id for this locked post' );
-define( "PATREON_WORDPRESS_VERSION", '1.8.5' );
+define( "PATREON_WORDPRESS_VERSION", '1.8.6' );
 define( "PATREON_WORDPRESS_BETA_STRING", '' );
 define( "PATREON_WORDPRESS_PLUGIN_SLUG", plugin_basename( __FILE__ ) );
 define( "PATREON_PRIVACY_POLICY_ADDENDUM", '<h2>Patreon features in this website</h2>In order to enable you to use this website with Patreon services, we save certain functionally important Patreon information about you in this website if you log in with Patreon.

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressorg@patreon.com, codebard
 Tags: patreon, membership, members
 Requires at least: 4.0
 Requires PHP: 5.4
-Tested up to: 6.0
-Stable tag: 1.8.5
+Tested up to: 6.1.1
+Stable tag: 1.8.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,11 @@ To make a locked post public again, just choose "Everyone" from the select box a
 It is  difficult to protect videos due the intensive bandwidth requirements of hosting video  and having to rely on third parties such as Youtube or Vimeo. Youtube allows you to set videos to ‘private’ but Vimeo offers extra controls by only allowing videos to be played on specific domains. Visit this guide to [protecting your video content with Vimeo](https://help.vimeo.com/hc/en-us/articles/224817847-Privacy-settings-overview).
 
 == Upgrade Notice ==
+
+= 1.8.6 =
+
+* Added pledge info cache. Made getUserPatronage use pledge info cache. Added code to use current_user_pledge_amount for compatibility reasons if a user is not provided and current user is being used. Fixes the bug with providing $user to getUserPatronage and still ending up with current user's pledge result instead of the provided user's.
+* Added filter to allow modification of app info collection results to be used in setup wizard.
 
 = 1.8.5 =
 
@@ -470,6 +475,11 @@ Not at all - you can post different content totally independently at your site a
 Nothing will be changed at your site - the plugin will just connect your site to Patreon to allow communication in between your site and Patreon.
 
 == Changelog ==
+
+= 1.8.6 =
+
+* Added pledge info cache. Made getUserPatronage use pledge info cache. Added code to use current_user_pledge_amount for compatibility reasons if a user is not provided and current user is being used. Fixes the bug with providing $user to getUserPatronage and still ending up with current user's pledge result instead of the provided user's.
+* Added filter to allow modification of app info collection results to be used in setup wizard.
 
 = 1.8.5 =
 


### PR DESCRIPTION
= 1.8.6 =

* Added pledge info cache. Made getUserPatronage use pledge info cache. Added code to use current_user_pledge_amount for compatibility reasons if a user is not provided and current user is being used. Fixes the bug with providing $user to getUserPatronage and still ending up with current user's pledge result instead of the provided user's.

* Added filter to allow modification of app info collection results to be used in setup wizard.
