### PR TITLE
1.9.1

### DIFF
--- a/classes/patreon_protect.php
+++ b/classes/patreon_protect.php
@@ -645,8 +645,7 @@ class Patreon_Protect {
 		$append = PHP_EOL . "# BEGIN Patreon WordPress Image Protection
 RewriteEngine On
 RewriteBase /		
-RewriteCond %{REQUEST_FILENAME} (\.png|\.jpg|\.gif|\.jpeg|\.bmp)
-RewriteCond %{HTTP_REFERER} !^wp-admin [NC]
+RewriteCond %{REQUEST_FILENAME} (\.png|\.jpg|\.gif|\.jpeg|\.bmp) [NC]
 RewriteRule ^" . $upload_dir . "/(.*)$ index.php?patreon_action=serve_patron_only_image&patron_only_image=$1 [QSA,L]
 # END Patreon WordPress".PHP_EOL;
 		

--- a/patreon.php
+++ b/patreon.php
@@ -4,7 +4,7 @@
 Plugin Name: Patreon Wordpress
 Plugin URI: https://www.patreon.com/apps/wordpress
 Description: Patron-only content, directly on your website.
-Version: 1.9.0
+Version: 1.9.1
 Author: Patreon <platform@patreon.com>
 Author URI: https://patreon.com
 */
@@ -68,7 +68,7 @@ define( "PATREON_ADMIN_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons on
 define( "PATREON_CREATOR_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons only, it\'s not locked for you because you are logged in as the Patreon creator' );
 define( "PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST", 'Post is already public. If you would like to lock this post, please set a pledge level for it' );
 define( "PATREON_NO_POST_ID_TO_UNLOCK_POST", 'Sorry - could not get the post id for this locked post' );
-define( "PATREON_WORDPRESS_VERSION", '1.9.0' );
+define( "PATREON_WORDPRESS_VERSION", '1.9.1' );
 define( "PATREON_WORDPRESS_BETA_STRING", '' );
 define( "PATREON_WORDPRESS_PLUGIN_SLUG", plugin_basename( __FILE__ ) );
 define( "PATREON_PRIVACY_POLICY_ADDENDUM", '<h2>Patreon features in this website</h2>In order to enable you to use this website with Patreon services, we save certain functionally important Patreon information about you in this website if you log in with Patreon.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: patreon, membership, members
 Requires at least: 4.0
 Requires PHP: 7.4
 Tested up to: 6.5.3
-Stable tag: 1.9.0
+Stable tag: 1.9.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,10 @@ To make a locked post public again, just choose "Everyone" from the select box a
 It is  difficult to protect videos due the intensive bandwidth requirements of hosting video  and having to rely on third parties such as Youtube or Vimeo. Youtube allows you to set videos to ‘private’ but Vimeo offers extra controls by only allowing videos to be played on specific domains. Visit this guide to [protecting your video content with Vimeo](https://help.vimeo.com/hc/en-us/articles/224817847-Privacy-settings-overview).
 
 == Upgrade Notice ==
+
+= 1.9.1 =
+
+* An issue that made it possible to circumvent image locking by sending a specific referrer header was fixed. Now locked images should not allow circumvention of the protection via referer header
 
 = 1.9.0 =
 
@@ -506,6 +510,10 @@ Nothing will be changed at your site - the plugin will just connect your site to
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/patreon-connect)
 
 == Changelog ==
+
+= 1.9.1 =
+
+* An issue that made it possible to circumvent image locking by sending a specific referrer header was fixed. Now locked images should not allow circumvention of the protection via referer header
 
 = 1.9.0 =
 


### PR DESCRIPTION
* An issue that made it possible to circumvent image locking by sending a specific referrer header was fixed. Now locked images should not allow circumvention of the protection via referer header