### PR TITLE
1.9.5

### DIFF
--- a/classes/patreon_api_v2.php
+++ b/classes/patreon_api_v2.php
@@ -196,7 +196,13 @@ class Patreon_API {
 			'params' => $postfields,
 		);
 		
-		return $this->__get_json( "webhooks", $args );
+		$response = $this->__get_json( "webhooks", $args );
+
+		if ( isset( $response['errors'] ) AND isset( $response['errors'][0] ) AND isset( $response['errors'][0]['status'] ) AND $response['errors'][0]['status'] == '401' ) {
+			update_option( 'patreon-creator-access-token-401', true );
+		}
+		
+		return $response;
 	}
 	public function delete_post_webhook( $webhook_id ) {
 		

--- a/classes/patreon_metabox.php
+++ b/classes/patreon_metabox.php
@@ -46,7 +46,11 @@ class Patron_Metabox {
 		
 		global $post;
 		
-		$label    = 'Require the below membership tier or higher to view this post. (Makes entire post patron only)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-1?utm_source=' . urlencode( site_url() ) . '&utm_medium=patreon_wordpress_plugin&utm_campaign=&utm_content=post_locking_metabox_link_1&utm_term=" target="_blank">(?)</a>';		
+		$label    = 'Require the below membership tier or higher to view this post. (Makes entire post patron only)  <a href="https://www.patreondevelopers.com/t/patreon-wordpress-locking-options-guide/1135#heading--section-1?utm_source=' . urlencode( site_url() ) . '&utm_medium=patreon_wordpress_plugin&utm_campaign=&utm_content=post_locking_metabox_link_1&utm_term=" target="_blank">(?)</a>';
+		
+		if ( get_option( 'patreon-creator-access-token-401', false ) ) {
+			$label = '<div style="color: #ffa00f;">Sorry, it looks like your site\'s connection to Patreon is broken. Please <a href="' . admin_url( 'admin.php?page=patreon-plugin' ). '">click here</a> to reconnect by using the "(re)Connect site" button.</div><br>' . $label;
+		}
 		
 		// Override messaging for lite plans
 		

--- a/classes/patreon_options.php
+++ b/classes/patreon_options.php
@@ -110,6 +110,14 @@ class Patreon_Options {
                                 <div class="inside">
 									
 									<div id="patreon_options_app_details_main">
+
+										<?php
+
+											if ( get_option( 'patreon-creator-access-token-401', false ) ) {
+												echo '<div style="color: #ffa00f;">Sorry, it looks like your site\'s connection to Patreon is broken. Please reconnect by using the "(re)Connect site" button.</div><br>';
+											}
+										?>
+		
 									
 										<button class="button button-primary button-large patreon_wordpress_interface_toggle" toggle="patreon-connection-details" aria-label="Patreon connection details">Connection details</button><?php // Immediately inserted here to not cause any funny html rendering
 										

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -382,6 +382,8 @@ class Patreon_Routing {
 								update_option( 'patreon-setup-done', true );
 								update_option( 'patreon-redirect_to_setup_wizard', false );
 								update_option( 'patreon-setup-wizard-last-call-result', $client_result );
+
+								delete_option( 'patreon-creator-access-token-401' );
 								
 								// Redirect to success screen
 								
@@ -507,6 +509,8 @@ class Patreon_Routing {
 								update_option( 'patreon-setup-done', true );
 								update_option( 'patreon-redirect_to_setup_wizard', false );
 								update_option( 'patreon-setup-wizard-last-call-result', $client_result );
+
+								delete_option( 'patreon-creator-access-token-401' );
 								
 								// Redirect to success screen
 								

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -3157,6 +3157,10 @@ class Patreon_Wordpress {
 		if (is_admin()) {
 			return;
 		}
+
+		if ( get_option( 'patreon-creator-access-token-401', false ) ) {
+			return;		
+		}
 		
 		$api_version = get_option( 'patreon-installation-api-version', '1' );
 
@@ -3202,12 +3206,13 @@ class Patreon_Wordpress {
 			
 			return;			
 		}
-		
+
 		// If webhook already added, skip
+
 		if ( get_option( 'patreon-post-sync-webhook-saved', false ) ) {
 			return;			
 		}
-		
+
 		$creator_access_token = get_option( 'patreon-creators-access-token', false );
 		
 		$api_client = new Patreon_API( $creator_access_token );

--- a/patreon.php
+++ b/patreon.php
@@ -4,7 +4,7 @@
 Plugin Name: Patreon Wordpress
 Plugin URI: https://www.patreon.com/apps/wordpress
 Description: Patron-only content, directly on your website.
-Version: 1.9.4
+Version: 1.9.5
 Author: Patreon <platform@patreon.com>
 Author URI: https://patreon.com
 */
@@ -68,7 +68,7 @@ define( "PATREON_ADMIN_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons on
 define( "PATREON_CREATOR_BYPASSES_FILTER_MESSAGE", 'This content is for Patrons only, it\'s not locked for you because you are logged in as the Patreon creator' );
 define( "PATREON_NO_LOCKING_LEVEL_SET_FOR_THIS_POST", 'Post is already public. If you would like to lock this post, please set a pledge level for it' );
 define( "PATREON_NO_POST_ID_TO_UNLOCK_POST", 'Sorry - could not get the post id for this locked post' );
-define( "PATREON_WORDPRESS_VERSION", '1.9.4' );
+define( "PATREON_WORDPRESS_VERSION", '1.9.5' );
 define( "PATREON_WORDPRESS_BETA_STRING", '' );
 define( "PATREON_WORDPRESS_PLUGIN_SLUG", plugin_basename( __FILE__ ) );
 define( "PATREON_PRIVACY_POLICY_ADDENDUM", '<h2>Patreon features in this website</h2>In order to enable you to use this website with Patreon services, we save certain functionally important Patreon information about you in this website if you log in with Patreon.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: patreon, membership, members
 Requires at least: 4.0
 Requires PHP: 7.4
 Tested up to: 6.7.1
-Stable tag: 1.9.4
+Stable tag: 1.9.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,10 @@ To make a locked post public again, just choose "Everyone" from the select box a
 It is  difficult to protect videos due the intensive bandwidth requirements of hosting video  and having to rely on third parties such as Youtube or Vimeo. Youtube allows you to set videos to ‘private’ but Vimeo offers extra controls by only allowing videos to be played on specific domains. Visit this guide to [protecting your video content with Vimeo](https://help.vimeo.com/hc/en-us/articles/224817847-Privacy-settings-overview).
 
 == Upgrade Notice ==
+
+= 1.9.5 =
+
+* Fixed a bug that was causing the plugin to continue attempting to create a post sync webhook when API connection was broken. Added an option flag for marking broken connections. Added notices and callouts to post level metabox and plugin admin to notify that the site needs to be reconnected.
 
 = 1.9.4 =
 
@@ -524,6 +528,10 @@ Nothing will be changed at your site - the plugin will just connect your site to
 You can report security bugs through the Patchstack Vulnerability Disclosure Program. The Patchstack team help validate, triage and handle any security vulnerabilities. [Report a security vulnerability.](https://patchstack.com/database/vdp/patreon-connect)
 
 == Changelog ==
+
+= 1.9.5 =
+
+* Fixed a bug that was causing the plugin to continue attempting to create a post sync webhook when API connection was broken. Added an option flag for marking broken connections. Added notices and callouts to post level metabox and plugin admin to notify that the site needs to be reconnected.
 
 = 1.9.4 =
 


### PR DESCRIPTION
= 1.9.5 =

* Fixed a bug that was causing the plugin to continue attempting to create a post sync webhook when API connection was broken. Added an option flag for marking broken connections. Added notices and callouts to post level metabox and plugin admin to notify that the site needs to be reconnected.