### PR TITLE
Use campaign name instead of creator's display_name for unlock button

### DIFF
--- a/classes/patreon_api_v2.php
+++ b/classes/patreon_api_v2.php
@@ -58,7 +58,7 @@ class Patreon_API
 
     public function fetch_creator_info()
     {
-        $api_return = $this->__get_json('campaigns?include=creator&fields[campaign]=created_at,creation_name,discord_server_id,image_small_url,image_url,is_charged_immediately,is_monthly,is_nsfw,main_video_embed,main_video_url,one_liner,one_liner,patron_count,pay_per_name,pledge_url,published_at,summary,thanks_embed,thanks_msg,thanks_video_url,has_rss,has_sent_rss_notify,rss_feed_title,rss_artwork_url,patron_count,discord_server_id,google_analytics_id&fields[user]=about,created,email,first_name,full_name,image_url,last_name,social_connections,thumb_url,url,vanity,is_email_verified', ['include_http_status' => true]);
+        $api_return = $this->__get_json('campaigns?include=creator&fields[campaign]=name,created_at,creation_name,discord_server_id,image_small_url,image_url,is_charged_immediately,is_monthly,is_nsfw,main_video_embed,main_video_url,one_liner,one_liner,patron_count,pay_per_name,pledge_url,published_at,summary,thanks_embed,thanks_msg,thanks_video_url,has_rss,has_sent_rss_notify,rss_feed_title,rss_artwork_url,patron_count,discord_server_id,google_analytics_id&fields[user]=about,created,email,first_name,full_name,image_url,last_name,social_connections,thumb_url,url,vanity,is_email_verified', ['include_http_status' => true]);
 
         return $api_return;
     }

--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -1386,7 +1386,7 @@ class Patreon_Frontend
         $creator_interface_name = Patreon_Wordpress::get_page_name();
 
         if (!$creator_interface_name or '' == $creator_interface_name) {
-            $creator_interface_name = get_option('patreon-creator-first-name', false);
+            $creator_interface_name = get_option('patreon-campaign-name', false);
         }
 
         if (!$creator_interface_name or '' == $creator_interface_name) {

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -84,7 +84,7 @@ class Patreon_Wordpress
         add_action('init', [$this, 'check_creator_token_expiration']);
         add_action('init', [$this, 'checkPatreonCampaignID']);
         add_action('init', [$this, 'checkPatreonCreatorURL']);
-        add_action('init', [$this, 'checkPatreonCreatorName']);
+        add_action('init', [$this, 'checkPatreonCampaignName']);
         add_action('init', 'Patreon_Login::checkTokenExpiration');
         add_action('admin_enqueue_scripts', [$this, 'enqueueAdminScripts']);
         add_action('upgrader_process_complete', 'Patreon_Wordpress::AfterUpdateActions', 10, 2);
@@ -422,28 +422,29 @@ class Patreon_Wordpress
         }
     }
 
-    public static function checkPatreonCreatorName()
+    public static function checkPatreonCampaignName()
     {
-        // This function checks and saves creator's full name, name and surname. These are used in post locking interface
+        // This function checks and saves campaign name and creator's name details. These are used in post locking interface
 
-        if (!get_option('patreon-creator-full-name', false) or '' == get_option('patreon-creator-full-name', false)) {
+        if (!get_option('patreon-campaign-name', false) or '' == get_option('patreon-campaign-name', false)) {
             // Making sure access credentials are there to avoid fruitlessly contacting the api:
 
             if (get_option('patreon-client-id', false) && get_option('patreon-client-secret', false) && get_option('patreon-creators-access-token', false)) {
                 // Credentials are in. Go.
                 $creator_info = self::getPatreonCreatorInfo();
-            }
-            if (isset($creator_info['included'][0]['attributes']['full_name'])) {
-                // Creator id acquired. Update.
-                update_option('patreon-creator-full-name', $creator_info['included'][0]['attributes']['full_name']);
-            }
-            if (isset($creator_info['included'][0]['attributes']['first_name'])) {
-                // Creator id acquired. Update.
-                update_option('patreon-creator-first-name', $creator_info['included'][0]['attributes']['first_name']);
-            }
-            if (isset($creator_info['included'][0]['attributes']['last_name'])) {
-                // Creator id acquired. Update.
-                update_option('patreon-creator-last-name', $creator_info['included'][0]['attributes']['last_name']);
+
+                if (isset($creator_info['data'][0]['attributes']['name'])) {
+                    update_option('patreon-campaign-name', $creator_info['data'][0]['attributes']['name']);
+                }
+                if (isset($creator_info['included'][0]['attributes']['full_name'])) {
+                    update_option('patreon-creator-full-name', $creator_info['included'][0]['attributes']['full_name']);
+                }
+                if (isset($creator_info['included'][0]['attributes']['first_name'])) {
+                    update_option('patreon-creator-first-name', $creator_info['included'][0]['attributes']['first_name']);
+                }
+                if (isset($creator_info['included'][0]['attributes']['last_name'])) {
+                    update_option('patreon-creator-last-name', $creator_info['included'][0]['attributes']['last_name']);
+                }
             }
         }
     }
@@ -1859,6 +1860,7 @@ class Patreon_Wordpress
                 $options_to_delete = [
                     'patreon-custom-page-name',
                     'patreon-fetch-creator-id',
+                    'patreon-campaign-name',
                     'patreon-creator-tiers',
                     'patreon-creator-last-name',
                     'patreon-creator-first-name',
@@ -2465,6 +2467,7 @@ class Patreon_Wordpress
             $options_to_delete = [
                 'patreon-custom-page-name',
                 'patreon-fetch-creator-id',
+                'patreon-campaign-name',
                 'patreon-creator-tiers',
                 'patreon-creator-last-name',
                 'patreon-creator-first-name',
@@ -2562,6 +2565,7 @@ class Patreon_Wordpress
             $options_to_delete = [
                 'patreon-custom-page-name',
                 'patreon-fetch-creator-id',
+                'patreon-campaign-name',
                 'patreon-creator-tiers',
                 'patreon-creator-last-name',
                 'patreon-creator-first-name',


### PR DESCRIPTION
### Problem
The plugin uses `user.display_name` in the unlock flow.

### Solution
Use `campaign.name` instead.

Before
<img width="1000" alt="Screenshot 2025-05-08 at 10 54 41 AM" src="https://github.com/user-attachments/assets/08f3e659-74ee-4932-9fd0-0e265a37dff9" />


After
<img width="789" alt="Screenshot 2025-05-08 at 10 33 10 AM" src="https://github.com/user-attachments/assets/6b588de7-f36c-4080-b4d1-0d50787135fd" />
