### PR TITLE
Log reason why a connection might've failed

### DIFF
--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -530,6 +530,8 @@ class Patreon_Routing
                             wp_redirect($setup_final_redirect);
                             exit;
                         }
+                    } elseif (isset($client_result['errors'])) {
+                        Patreon_Wordpress::log_connection_error('Failed to create connection. Response: '.json_encode($client_result['errors']));
                     }
 
                     // If we are here, something else is wrong. Come out with an error


### PR DESCRIPTION
### Problem
Connecting WP plugin can sometimes fail (ex - user not having a creator account).
Some of these failures don't provide enough context to the user. For now at least
add a system log so users can find a more detailed reason in the healthcheck section.

### Solution
Log error response to be visible in the health-check section for basic debugging.