### PR TITLE
Prevent infinite creator token refresh when tokens expire

### DIFF
--- a/classes/patreon_api_v2.php
+++ b/classes/patreon_api_v2.php
@@ -219,9 +219,8 @@ class Patreon_API
 
     public function create_refresh_client($params)
     {
-        // Contacts api to create or refresh client
-        // Only uses v2
-
+        // Create an oauth client on the behalf of the creator. The new client
+        // is a child of the Patreon WP client.
         $args = [
             'method' => 'POST',
             'params' => $params,

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -73,9 +73,9 @@ class Patreon_OAuth
             // Patreon's API with token refresh requests with invalid or expired
             // credentials.
             update_option('patreon-wordpress-app-credentials-failure', true);
-            Patreon_Wordpress::log_connection_error('Failed creator token get/update. Response:'.$response);
+            Patreon_Wordpress::log_connection_error('Failed get/update creator token. HTTP '.$status_code.', Response: '.$response['body']);
         } elseif (200 != $status_code) {
-            Patreon_Wordpress::log_connection_error('Failed token get/update. Response:'.$response);
+            Patreon_Wordpress::log_connection_error('Failed get/update token. HTTP '.$status_code.', Response: '.$response['body']);
         }
 
         $response_decoded = json_decode($response['body'], true);

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -70,9 +70,12 @@ class Patreon_OAuth
         if ($disable_app_on_auth_err && 401 == $status_code) {
             // Token refresh failed. Mark the app integration credentials as
             // bad. This is done for creator access token to prevent spamming
-            // Patreon's API with token refresh requests with invalid or expired
-            // credentials.
+            // Patreon's API with token refresh requests using invalid or
+            // expired credentials. Add a cooldown period when the token refresh
+            // could be retried.
             update_option('patreon-wordpress-app-credentials-failure', true);
+            set_transient('patreon-wordpress-app-creator-token-refresh-cooldown', true, PATREON_CREATOR_TOKEN_REFRESH_ATTEMPT_COOLDOWN_S);
+
             Patreon_Wordpress::log_connection_error('Failed get/update creator token. HTTP '.$status_code.', Response: '.$response['body']);
         } elseif (200 != $status_code) {
             Patreon_Wordpress::log_connection_error('Failed get/update token. HTTP '.$status_code.', Response: '.$response['body']);

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -82,8 +82,10 @@ class Patreon_OAuth
         }
 
         $response_decoded = json_decode($response['body'], true);
-        if (is_array($response_decoded)) {
-            return $response_decoded;
+        if (!is_array($response_decoded) || !isset($response_decoded['access_token'], $response_decoded['refresh_token'])) {
+            Patreon_Wordpress::log_connection_error('Invalid token refresh response '.$response['body']);
         }
+
+        return $response_decoded;
     }
 }

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -17,7 +17,7 @@ class Patreon_OAuth
 
     public function get_tokens($code, $redirect_uri, $params = [])
     {
-        // TODO: Can this be used for non-creator token? Should false/treu
+        // TODO: Can this be used for non-creator token? Should false/true
         return $this->__update_token(
             array_merge(
                 [
@@ -35,6 +35,8 @@ class Patreon_OAuth
     public function refresh_token($refresh_token, $redirect_uri, $is_creator_token)
     {
         if (PatreonApiUtil::is_credentials_broken()) {
+            // Don't allow token refresh if the credentials have been marked as
+            // broken.
             return;
         }
 
@@ -73,6 +75,7 @@ class Patreon_OAuth
         $status_code = wp_remote_retrieve_response_code($response);
 
         if ($is_creator_token && 401 == $status_code) {
+            // Mark credentials as invalid
             update_option('patreon-wordpress-app-credentials-failure', true);
         }
 

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -530,6 +530,8 @@ class Patreon_Routing
                             wp_redirect($setup_final_redirect);
                             exit;
                         }
+                    } elseif (isset($client_result['errors'])) {
+                        Patreon_Wordpress::log_connection_error('Failed to create connection. Response: '.json_encode($client_result['errors']));
                     }
 
                     // If we are here, something else is wrong. Come out with an error

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -235,7 +235,7 @@ class Patreon_Wordpress
         $refresh_token = get_user_meta($user->ID, 'patreon_refresh_token', true);
 
         $oauth_client = new Patreon_Oauth();
-        $tokens = $oauth_client->refresh_token($refresh_token, site_url().'/patreon-authorization/');
+        $tokens = $oauth_client->refresh_token($refresh_token, site_url().'/patreon-authorization/', false);
 
         if (isset($tokens['access_token'])) {
             update_user_meta($user->ID, 'patreon_refresh_token', $tokens['refresh_token']);
@@ -446,7 +446,7 @@ class Patreon_Wordpress
         }
 
         $oauth_client = new Patreon_Oauth();
-        $tokens = $oauth_client->refresh_token($refresh_token, site_url().'/patreon-authorization/');
+        $tokens = $oauth_client->refresh_token($refresh_token, site_url().'/patreon-authorization/', true);
 
         if (isset($tokens['refresh_token']) && isset($tokens['access_token'])) {
             update_option('patreon-creators-refresh-token', $tokens['refresh_token']);
@@ -948,7 +948,6 @@ class Patreon_Wordpress
                 </div>
             <?php
 
-            delete_option('patreon-wordpress-app-credentials-failure');
         }
     }
 
@@ -1349,6 +1348,7 @@ class Patreon_Wordpress
 
         if ($creator_access) {
             update_option('patreon-wordpress-app-credentials-success', 1);
+            delete_option('patreon-wordpress-app-credentials-failure');
 
             return;
         }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -1354,7 +1354,7 @@ class Patreon_Wordpress
         }
 
         // All flopped. Set failure flag
-        update_option('patreon-wordpress-app-credentials-failure', 1);
+        update_option('patreon-wordpress-app-credentials-failure', true);
     }
 
     public function toggle_option()

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -439,7 +439,6 @@ class Patreon_Wordpress
     public static function refresh_creator_access_token()
     {
         $lock_key = 'patreon-wordpress-app-creator-token-refresh-lock';
-        $tokens = null;
 
         if (get_transient($lock_key)) {
             return false;

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -438,6 +438,12 @@ class Patreon_Wordpress
 
     public static function refresh_creator_access_token()
     {
+        if (PatreonApiUtil::is_app_creds_invalid()) {
+            // Don't attempt creator token refresh if the plugin client
+            // credentials have been marked as broken
+            return false;
+        }
+
         /* refresh creators token if error 1 */
         $refresh_token = get_option('patreon-creators-refresh-token', false);
 
@@ -927,7 +933,7 @@ class Patreon_Wordpress
 
         // This is a plugin system info notice.
         if (get_option('patreon-wordpress-app-credentials-success', false)) {
-            // Non-important non-permanent info notice - doesnt need nonce verification
+            // Non-important non-permanent info notice - doesn't need nonce verification
             ?>
                  <div class="notice notice-success is-dismissible patreon-wordpress" id="patreon-wordpress-credentials-success">
                  <h3>Your Patreon client details were successfully saved!</h3>
@@ -939,8 +945,8 @@ class Patreon_Wordpress
         }
 
         // This is a plugin system info notice.
-        if (get_option('patreon-wordpress-app-credentials-failure', false)) {
-            // Non-important non-permanent info notice - doesnt need nonce verification
+        if (PatreonApiUtil::is_app_creds_invalid()) {
+            // Non-important non-permanent info notice - doesn't need nonce verification
             ?>
                  <div class="notice notice-error is-dismissible patreon-wordpress" id="patreon-wordpress-credentials-failure">
                  <h3>Sorry - couldn't connect your site to Patreon</h3>

--- a/includes/patreon_api_util.php
+++ b/includes/patreon_api_util.php
@@ -12,6 +12,11 @@ class PatreonApiUtil
         return get_option('patreon-wordpress-app-credentials-failure', false);
     }
 
+    public static function is_creator_token_refresh_cooldown()
+    {
+        return get_transient('patreon-wordpress-app-creator-token-refresh-cooldown');
+    }
+
     private static function get_patreon_ua()
     {
         $campaign_id = get_option('patreon-campaign-id', '?');

--- a/includes/patreon_api_util.php
+++ b/includes/patreon_api_util.php
@@ -7,7 +7,7 @@ class PatreonApiUtil
         return ['User-Agent' => self::get_patreon_ua()];
     }
 
-    public static function is_credentials_broken()
+    public static function is_app_creds_invalid()
     {
         return get_option('patreon-wordpress-app-credentials-failure', false);
     }

--- a/includes/patreon_api_util.php
+++ b/includes/patreon_api_util.php
@@ -7,6 +7,11 @@ class PatreonApiUtil
         return ['User-Agent' => self::get_patreon_ua()];
     }
 
+    public static function is_credentials_broken()
+    {
+        return get_option('patreon-wordpress-app-credentials-failure', false);
+    }
+
     private static function get_patreon_ua()
     {
         $campaign_id = get_option('patreon-campaign-id', '?');

--- a/patreon.php
+++ b/patreon.php
@@ -144,6 +144,7 @@ define('PATREON_ALL_POST_CATEGORY_FIELDS_MUST_BE_SELECTED', 'Please select all p
 define('PATREON_API_VERSION_WARNING', 'Your plugin is still using API v1! This will cause errors when you use post sync feature! Please read <a href="https://www.patreondevelopers.com/t/how-to-upgrade-your-patreon-wordpress-to-use-api-v2/3249" target="_blank">this guide</a> to upgrade your plugin to API v2 before activating post sync.');
 define('PATREON_WARNING_IMPORTANT', 'Important: ');
 define('PATREON_WARNING_POST_SYNC_SET_WITHOUT_API_V2', 'Important: Post syncing from Patreon is set to on, but your site is using API v1. Post sync wont work without API v2. Follow <a href="https://www.patreondevelopers.com/t/how-to-upgrade-your-patreon-wordpress-to-use-api-v2/3249" target="_blank">this guide</a> to upgrade your site to API v2 or disable post sync <a href="'.admin_url('admin.php?page=patreon-plugin').'">here in settings</a>');
+define('PATREON_CREATOR_TOKEN_REFRESH_ATTEMPT_COOLDOWN_S', 5 * 10);
 
 require 'classes/patreon_wordpress.php';
 


### PR DESCRIPTION
### Problem
Some Patreon WP Plugin setups might have invalid or expired client credentials.
The plugin indefinitely attempts to refresh expired tokens. This results with high
number of invalid (4xx) requests to Patreon's API which in return results with the
ip being temporarily blocked.


### Solution
1. Detect a 401 response when attempting to get a new creator access token
2. Mark the integration credentials as invalid if 401 was returned
3. Show a notice that the credentials have expired
4. Add a colldown period to creator token refresh logic to prevent refresh for
10 minutes if a previous refresh failed with a 401.
3. Add a lock to creator token refresh process to prevent a race condition