### PR TITLE
Prevent repeated oAuth token refresh attempts for patrons with invalid token data

### DIFF
--- a/classes/patreon_constants.php
+++ b/classes/patreon_constants.php
@@ -1,0 +1,6 @@
+<?php
+
+class PatreonTimeConstants
+{
+    public const DAY_S = 86400;
+}

--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -15,6 +15,14 @@ class Patreon_Login
         update_user_meta($user_id, 'patreon_token_minted', microtime());
     }
 
+    public static function clear_user_token_data($user_id)
+    {
+        delete_user_meta($user_id, 'patreon_access_token');
+        delete_user_meta($user_id, 'patreon_refresh_token');
+        delete_user_meta($user_id, 'patreon_token_expires_in');
+        delete_user_meta($user_id, 'patreon_token_minted');
+    }
+
     public static function updateExistingUser($user_id, $user_response, $tokens)
     {
         /* update user meta data with patreon data */
@@ -95,14 +103,6 @@ class Patreon_Login
                 self::clear_user_token_data($user->ID);
             }
         }
-    }
-
-    public static function clear_user_token_data($user_id)
-    {
-        delete_user_meta($user_id, 'patreon_access_token');
-        delete_user_meta($user_id, 'patreon_refresh_token');
-        delete_user_meta($user_id, 'patreon_token_expires_in');
-        delete_user_meta($user_id, 'patreon_token_minted');
     }
 
     public static function createOrLogInUserFromPatreon($user_response, $tokens, $redirect = false)

--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -68,6 +68,10 @@ class Patreon_Login
             $expiration = get_user_meta($user->ID, 'patreon_token_expires_in', true);
             $minted = get_user_meta($user->ID, 'patreon_token_minted', true);
 
+            if (!$expiration) {
+                return null;
+            }
+
             if ('' != $minted) {
                 // We have value. get secs to use them in comparison.
 

--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -7,11 +7,18 @@ if (!defined('WPINC')) {
 
 class Patreon_Login
 {
+    public static function set_user_token_data($user_id, $access_token, $refresh_token, $expires_in)
+    {
+        update_user_meta($user_id, 'patreon_access_token', $access_token);
+        update_user_meta($user_id, 'patreon_refresh_token', $refresh_token);
+        update_user_meta($user_id, 'patreon_token_expires_in', $expires_in);
+        update_user_meta($user_id, 'patreon_token_minted', microtime());
+    }
+
     public static function updateExistingUser($user_id, $user_response, $tokens)
     {
         /* update user meta data with patreon data */
-        update_user_meta($user_id, 'patreon_refresh_token', $tokens['refresh_token']);
-        update_user_meta($user_id, 'patreon_access_token', $tokens['access_token']);
+        self::set_user_token_data($user_id, $tokens['access_token'], $tokens['refresh_token'], $tokens['expires_in']);
         update_user_meta($user_id, 'patreon_user', $user_response['data']['attributes']['vanity']);
         update_user_meta($user_id, 'patreon_user_id', $user_response['data']['id']);
         update_user_meta($user_id, 'patreon_last_logged_in', time());
@@ -22,8 +29,6 @@ class Patreon_Login
         }
 
         update_user_meta($user_id, 'patreon_created', $patreon_created);
-        update_user_meta($user_id, 'patreon_token_minted', microtime());
-        update_user_meta($user_id, 'patreon_token_expires_in', $tokens['expires_in']);
 
         $user = get_user_by('ID', $user_id);
 
@@ -97,6 +102,7 @@ class Patreon_Login
         delete_user_meta($user_id, 'patreon_access_token');
         delete_user_meta($user_id, 'patreon_refresh_token');
         delete_user_meta($user_id, 'patreon_token_expires_in');
+        delete_user_meta($user_id, 'patreon_token_minted');
     }
 
     public static function createOrLogInUserFromPatreon($user_response, $tokens, $redirect = false)

--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -86,6 +86,22 @@ class Patreon_OAuth
             Patreon_Wordpress::log_connection_error('Invalid token refresh response '.$response['body']);
         }
 
-        return $response_decoded;
+        $result = [];
+
+        if (isset($response_decoded['access_token'])) {
+            $result['access_token'] = $response_decoded['access_token'];
+        }
+
+        if (isset($response_decoded['refresh_token'])) {
+            $result['refresh_token'] = $response_decoded['refresh_token'];
+        }
+
+        if (isset($response_decoded['expires_in'])) {
+            $result['expires_in'] = $response_decoded['expires_in'];
+        }
+
+        $result['http_status_code'] = $status_code;
+
+        return $result;
     }
 }

--- a/classes/patreon_options.php
+++ b/classes/patreon_options.php
@@ -877,7 +877,7 @@ class Patreon_Options
 
         if (count($last_50_conn_errors) > 0) {
             foreach ($last_50_conn_errors as $key => $value) {
-                $days = abs(time() - $last_50_conn_errors[$key]['date']) / 86400;
+                $days = abs(time() - $last_50_conn_errors[$key]['date']) / PatreonTimeConstants::DAY_S;
 
                 echo '<br /><br /><b>'.round($days, 2).' days ago</b><br /><br />';
                 echo $last_50_conn_errors[$key]['error'];

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -43,6 +43,7 @@ class Patreon_Wordpress
         include_once 'patreon_compatibility.php';
         include_once 'patreon_admin_pointers.php';
         include_once 'patreon_content_sync.php';
+        include_once 'patreon_constants.php';
 
         self::$patreon_routing = new Patreon_Routing();
         self::$patreon_frontend = new Patreon_Frontend();
@@ -220,7 +221,7 @@ class Patreon_Wordpress
             $user_response_timestamp = get_user_meta($user->ID, 'patreon_latest_patron_info_timestamp', true);
 
             // Check if there is a valid saved user return and whether it has a timestamp within desired range
-            if (isset($user_response['included'][0]) and is_array($user_response['included'][0]) and $user_response_timestamp >= (time() - (3600 * 24 * 3))) {
+            if (isset($user_response['included'][0]) and is_array($user_response['included'][0]) and $user_response_timestamp >= (time() - 3 * PatreonTimeConstants::DAY_S)) {
                 return Patreon_Wordpress::add_to_patreon_user_info_cache($user->ID, $user_response);
             }
         }
@@ -287,8 +288,7 @@ class Patreon_Wordpress
         $last_update = get_user_meta($user->ID, 'patreon_user_details_last_updated', true);
 
         // If last update time is not empty and it is closer to time() than one day, dont update
-        $one_day_s = 86400;
-        if (!('' == $last_update or ((time() - $last_update) > $one_day_s))) {
+        if (!('' == $last_update or ((time() - $last_update) > PatreonTimeConstants::DAY_S))) {
             return false;
         }
 

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -168,7 +168,6 @@ class Patreon_Wordpress
         $patreon_access_token = get_user_meta($user->ID, 'patreon_access_token', true);
 
         if ('' != $patreon_access_token) {
-            // TODO add wrong
             $api_client = new Patreon_API($patreon_access_token);
 
             // Get the user from the API
@@ -224,8 +223,6 @@ class Patreon_Wordpress
             if (isset($user_response['included'][0]) and is_array($user_response['included'][0]) and $user_response_timestamp >= (time() - (3600 * 24 * 3))) {
                 return Patreon_Wordpress::add_to_patreon_user_info_cache($user->ID, $user_response);
             }
-        } else {
-            echo 'Testing - no token';
         }
 
         // All failed - return false
@@ -255,11 +252,7 @@ class Patreon_Wordpress
             $refresh_data = $oauth_client->refresh_token($refresh_token, site_url().'/patreon-authorization/', false);
 
             if (isset($refresh_data['access_token'])) {
-                update_user_meta($user->ID, 'patreon_access_token', $refresh_data['access_token']);
-                update_user_meta($user->ID, 'patreon_refresh_token', $refresh_data['refresh_token']);
-                update_user_meta($user->ID, 'patreon_refresh_token', $refresh_data['refresh_token']);
-                update_user_meta($user->ID, 'patreon_token_expires_in', $refresh_data['expires_in']);
-                update_user_meta($user->ID, 'patreon_token_minted', microtime(true));
+                Patreon_Login::set_user_token_data($user->ID, $refresh_data['access_token'], $refresh_data['refresh_token'], $refresh_data['expires_in']);
 
                 return true;
             }
@@ -294,7 +287,6 @@ class Patreon_Wordpress
         $last_update = get_user_meta($user->ID, 'patreon_user_details_last_updated', true);
 
         // If last update time is not empty and it is closer to time() than one day, dont update
-        // TODO: comment out for testing
         $one_day_s = 86400;
         if (!('' == $last_update or ((time() - $last_update) > $one_day_s))) {
             return false;

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -237,7 +237,7 @@ class Patreon_Wordpress
     {
         $refresh_token = get_user_meta($user->ID, 'patreon_refresh_token', true);
 
-        if (!refresh_token || !$user->ID) {
+        if (!$refresh_token || !$user->ID) {
             return false;
         }
 
@@ -255,17 +255,18 @@ class Patreon_Wordpress
             $refresh_data = $oauth_client->refresh_token($refresh_token, site_url().'/patreon-authorization/', false);
 
             if (isset($refresh_data['access_token'])) {
-                update_user_meta($user->ID, 'patreon_refresh_token', $refresh_data['refresh_token']);
                 update_user_meta($user->ID, 'patreon_access_token', $refresh_data['access_token']);
+                update_user_meta($user->ID, 'patreon_refresh_token', $refresh_data['refresh_token']);
+                update_user_meta($user->ID, 'patreon_refresh_token', $refresh_data['refresh_token']);
+                update_user_meta($user->ID, 'patreon_token_expires_in', $refresh_data['expires_in']);
+                update_user_meta($user->ID, 'patreon_token_minted', microtime(true));
 
-                return $refresh_data['access_token'];
+                return true;
             }
 
             if (isset($refresh_data['http_status_code']) && 401 == $refresh_data['http_status_code']) {
                 // Token refresh failed, most likely invalid token data
-                delete_user_meta($user->ID, 'patreon_access_token');
-                delete_user_meta($user->ID, 'patreon_refresh_token');
-                delete_user_meta($user->ID, 'patreon_token_expires_in');
+                Patreon_Login::clear_user_token_data($user->ID);
                 // TODO: Might need to consider asking the user to re-auth with
                 // Patreon.
             }


### PR DESCRIPTION
### Problem
The WordPress plugin attempts to reload user data during page loads if it
hasn’t been refreshed in over a day. However, users can have invalid (expired)
OAuth tokens. Currently, the plugin does not detect or mark these tokens as expired.

As a result, it repeatedly issues POST /oauth2/token requests in an attempt to
refresh the access token, which consistently results in HTTP 401 responses. This
behavior can lead to unnecessary request volume and may cause rate limiting issues
for some integrations.

### Solution
1.Clear token data on refresh failure:
- If a token refresh fails with an `HTTP 401` response, delete the `access_token,`
  `refresh_token, and token_expires_in` fields from the user record. This prevents
  future refresh attempts, as an `access_token` is required to initiate the refresh
  process.
2. Update token metadata on successful refresh:
- After a successful token refresh, update the token creation timestamp and its
  expiration duration accordingly.



