### PR TITLE
Return object during creator token refresh only if the tokens were refreshed

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -493,9 +493,11 @@ class Patreon_Wordpress
                 update_option('patreon-creators-refresh-token', $tokens['refresh_token']);
                 update_option('patreon-creators-access-token', $tokens['access_token']);
                 delete_option('patreon-wordpress-app-credentials-failure');
+
+                return $tokens;
             }
 
-            return $tokens ?: false;
+            return false;
         } finally {
             delete_transient($lock_key);
         }


### PR DESCRIPTION
### Problem
The callers of `refresh_cretor_access_token` are looking for a truthy value
to decide whether the refresh was successful. A recent change modified 
`refresh_token` method and it now always returns a truthy value (it
includes http response code). This means that even 401 and 429
calls are considered as successful token refresh.

### Solution
Return token refresh data only if it included access & refresh tokens.