### PR TITLE
Set expiration and scope data on creator token refresh + minor refresh bugfixes

### DIFF
--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -100,6 +100,10 @@ class Patreon_OAuth
             $result['expires_in'] = $response_decoded['expires_in'];
         }
 
+        if (isset($response_decoded['scope'])) {
+            $result['scope'] = $response_decoded['scope'];
+        }
+
         $result['http_status_code'] = $status_code;
 
         return $result;

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -458,13 +458,17 @@ class Patreon_Wordpress
             }
         }
 
-        if ($should_refresh_tokens and $token_data = self::refresh_creator_access_token()) {
-            $api_client = new Patreon_API($token_data['access_token']);
+        if ($should_refresh_tokens) {
+            if ($token_data = self::refresh_creator_access_token()) {
+                $api_client = new Patreon_API($token_data['access_token']);
 
-            return $api_client->fetch_creator_info();
+                return $api_client->fetch_creator_info();
+            }
+        } else {
+            return $user_response;
         }
 
-        return $user_response;
+        return false;
     }
 
     public static function refresh_creator_access_token()


### PR DESCRIPTION
### Problem
The refresh token expiration time + scope information was not consistently persisted
across all creator token refresh scenarios.

I also discovered that one of the previous PRs excluded `scope` information from
token refresh method response, this should be included.

I also found out that an old access token might've been used immediately after
refreshing the token.

### Solution
1. Pull in logic that sets expiration & scope data into a centralised location
2. Update `__get_or_update_token` to include `scope` data in response obj
3. Make sure that updated access token is used after a successful token refresh
4. Minor refactors