### PR TITLE
Set correct variable for refresh token expiration

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -510,7 +510,7 @@ class Patreon_Wordpress
             }
 
             $new_expiration = time() + $expires_in;
-            update_option('patreon-creators-access-token-scope', $new_expiration);
+            update_option('patreon-creators-refresh-token-expiration', $new_expiration);
 
             if (isset($tokens['refresh_token']) && isset($tokens['access_token'])) {
                 update_option('patreon-creators-access-token', $tokens['access_token']);


### PR DESCRIPTION
### Problem
The token expiration was incorrectly set (PR https://github.com/Patreon/patreon-wordpress/pull/186) on the scope option and not the
expiration one. This meant that the expiration was considered being empty forcing
the plugin to perform creator token refresh.

### Solution
Set the `patreon-creators-refresh-token-expiration` option with the new expiration.
The `patreon-creators-access-token-scope` is only set & never used, the incorrect
value won't cause any issues. The tokens and thus scope info should rotate within 30
days.