### PR TITLE
Consider webhook delete successful with 404 response

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -3026,7 +3026,7 @@ class Patreon_Wordpress
                 $webhook_delete = $api_client->delete_post_webhook($existing_hook['data']['id']);
 
                 // If delete is successful remove the local info about webhook
-                if (is_array($webhook_delete) and isset($webhook_delete['response']['code']) and '204' == $webhook_delete['response']['code']) {
+                if (is_array($webhook_delete) and isset($webhook_delete['response']['code']) and in_array($webhook_delete['response']['code'], ['204', '404'])) {
                     update_option('patreon-post-sync-webhook-saved', false);
                     delete_option('patreon-post-sync-webhook');
                 }


### PR DESCRIPTION
### Problem
The webhook delete operation is considered successful only if a 204 status code
was returned. This can result with an infinity webhook delete retry loop.

### Solution
Consider both - `204` and `404` responses as successful webhook deletes.
