### PR TITLE
Add a queryparam to token refresh to indicate if refresh is for creator access token

### DIFF
--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -47,6 +47,16 @@ class Patreon_OAuth
     {
         $api_endpoint = 'https://'.PATREON_HOST.'/api/oauth2/token';
 
+        if ($disable_app_on_auth_err) {
+            // Debugging high number of 401s to the token API. Try to indicate
+            // whether the refresh event is for a creator token or not. Use the
+            // $disable_app_on_auth_err is usually set to true when working with
+            // creator access token.
+            $api_endpoint = $api_endpoint.'?is_creator_access=true';
+        } else {
+            $api_endpoint = $api_endpoint.'?is_creator_access=false';
+        }
+
         $headers = PatreonApiUtil::get_default_headers();
         $api_request = [
             'method' => 'POST',


### PR DESCRIPTION
### Problem
`POST /api/oauth2/token` results with high number of HTTP 401s. It's not
clear what's causing this. I would like to get more data on the api side
to understand what's triggering a token refresh.

### Solution
Add a `is_creator_access` queryparam to the token refresh call. This
queryparam is set based in the `$disable_app_on_auth_err` value, which
is usually set to `true` for creator access tokens.

This is temporary and can be eventually cleaned up.