### PR TITLE
Stop creator token refresh if app connection has been marked as broken

### DIFF
--- a/classes/patreon_oauth.php
+++ b/classes/patreon_oauth.php
@@ -78,14 +78,9 @@ class Patreon_OAuth
         $status_code = wp_remote_retrieve_response_code($response);
 
         if ($disable_app_on_auth_err && 401 == $status_code) {
-            // Token refresh failed. Mark the app integration credentials as
-            // bad. This is done for creator access token to prevent spamming
-            // Patreon's API with token refresh requests using invalid or
-            // expired credentials. Add a cooldown period when the token refresh
-            // could be retried.
+            // Token refresh failed - mark creator credentials invalid to avoid
+            // spamming Patreon's API with repeated refresh attempts
             update_option('patreon-wordpress-app-credentials-failure', true);
-            set_transient('patreon-wordpress-app-creator-token-refresh-cooldown', true, PATREON_CREATOR_TOKEN_REFRESH_ATTEMPT_COOLDOWN_S);
-
             Patreon_Wordpress::log_connection_error('Failed get/update creator token. HTTP '.$status_code.', Response: '.$response['body']);
         } elseif (200 != $status_code) {
             Patreon_Wordpress::log_connection_error('Failed get/update token. HTTP '.$status_code.', Response: '.$response['body']);

--- a/includes/patreon_api_util.php
+++ b/includes/patreon_api_util.php
@@ -3,6 +3,7 @@
 class PatreonApiUtil
 {
     public const CHECK_API_CONNECTION_COOLDOWN_KEY = 'patreon-check-api-connection-cooldown';
+    public const REFRESH_CREATOR_TOKEN_COOLDOWN_KEY = 'patreon-wordpress-app-creator-token-refresh-cooldown';
 
     public static function get_default_headers()
     {
@@ -14,9 +15,14 @@ class PatreonApiUtil
         return get_option('patreon-wordpress-app-credentials-failure', false);
     }
 
-    public static function is_creator_token_refresh_cooldown()
+    public static function get_creator_token_refresh_cooldown()
     {
-        return get_transient('patreon-wordpress-app-creator-token-refresh-cooldown');
+        return get_transient(self::REFRESH_CREATOR_TOKEN_COOLDOWN_KEY);
+    }
+
+    public static function set_creator_token_refresh_cooldown()
+    {
+        set_transient(self::REFRESH_CREATOR_TOKEN_COOLDOWN_KEY, true, PATREON_CREATOR_TOKEN_REFRESH_ATTEMPT_COOLDOWN_S);
     }
 
     public static function get_check_api_connection_cooldown()

--- a/patreon.php
+++ b/patreon.php
@@ -145,7 +145,7 @@ define('PATREON_API_VERSION_WARNING', 'Your plugin is still using API v1! This w
 define('PATREON_WARNING_IMPORTANT', 'Important: ');
 define('PATREON_WARNING_POST_SYNC_SET_WITHOUT_API_V2', 'Important: Post syncing from Patreon is set to on, but your site is using API v1. Post sync wont work without API v2. Follow <a href="https://www.patreondevelopers.com/t/how-to-upgrade-your-patreon-wordpress-to-use-api-v2/3249" target="_blank">this guide</a> to upgrade your site to API v2 or disable post sync <a href="'.admin_url('admin.php?page=patreon-plugin').'">here in settings</a>');
 define('PATREON_CHECK_API_CONNECTION_COOLDOWN_S', 10 * 60);
-define('PATREON_CREATOR_TOKEN_REFRESH_ATTEMPT_COOLDOWN_S', 5 * 10);
+define('PATREON_CREATOR_TOKEN_REFRESH_ATTEMPT_COOLDOWN_S', 60);
 
 require 'classes/patreon_wordpress.php';
 


### PR DESCRIPTION
### Problem
The WordPress plugin is generating an excessive number of  
`POST /api/oauth2/token` requests, many of which return `HTTP 401` responses.

https://github.com/Patreon/patreon-wordpress/pull/181 introduced logic to detect `401` responses during creator token refresh attempts
and mark the app credentials as invalid. It also implemented a 50-second cooldown
period to pause further creator token refresh attempts, which helped reduce API
traffic.

Despite this, clients with invalid credentials are still attempting to refresh creator
access tokens, continuing to send unnecessary requests to the Patreon API.

To avoid this, apps with invalid credentials should not attempt creator token
refreshes at all.

### Solution
- Skip creator access token refresh if app credentials are marked invalid.
- Move cooldown logic into `refresh_creator_access_token` to consolidate 
creator token refresh handling.