### PR TITLE
Re-Proposes Patreon Extended Cookie Login Option

### DIFF
--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -111,6 +111,7 @@ class Patreon_Login
 
         $login_with_patreon = get_option('patreon-enable-login-with-patreon', true);
         $admins_editors_login_with_patreon = get_option('patreon-enable-allow-admins-login-with-patreon', false);
+        $extend_patreon_cookie_login = get_option('patreon-extend-cookie-login', false);
         $danger_user_list = Patreon_Login::getDangerUserList();
 
         // Check if user is logged in to wp:
@@ -190,7 +191,12 @@ class Patreon_Login
                 } else {
                     /* log user into existing wordpress account with matching username */
                     wp_set_current_user($user->ID, $user->user_login);
-                    wp_set_auth_cookie($user->ID);
+                    /* check if the extended cookie expiration time option is selected */
+					if (false == $extend_patreon_cookie_login) {
+						wp_set_auth_cookie( $user->ID );
+					} else {
+						wp_set_auth_cookie( $user->ID, true ); /* second parameter set to true means "Remember Me", which sets the auth cookie expiration to 2 weeks */
+					}
                     do_action('wp_login', $user->user_login, $user);
 
                     // Import Patreon avatar for this user since it is a new user

--- a/classes/patreon_options.php
+++ b/classes/patreon_options.php
@@ -42,7 +42,8 @@ class Patreon_Options
         register_setting('patreon-options', 'patreon-can-use-api-v2');
         register_setting('patreon-options', 'patreon-enable-register-with-patreon');
         register_setting('patreon-options', 'patreon-enable-login-with-patreon');
-        register_setting('patreon-options', 'patreon-enable-allow-admins-login-with-patreon');
+        register_setting('patreon-options', 'patreon-extend-cookie-login');
+        register_setting('patreon-options', 'patreon-cookie-login-remember' );
         register_setting('patreon-options', 'patreon-enable-redirect-to-page-after-login');
         register_setting('patreon-options', 'patreon-enable-redirect-to-page-id');
         register_setting('patreon-options', 'patreon-protect-default-image-patreon-level');
@@ -346,6 +347,17 @@ class Patreon_Options
                                         </tr>
                                         <?php } ?>
 
+                                        <?php if (get_option('patreon-enable-login-with-patreon', true)) { ?>
+                                        <tr valign="top">
+                                            <th scope="row">
+                                                <strong>Extend Patreon Login cookie expiration</strong>
+                                                <div class="patreon-options-info">If on, Patreons will only have to re-sign in once your AUTH_COOKIE_EXPIRATION expires instead of every time they visit your website. Recommended: on</div>
+                                            </th>
+                                            <td>
+                                                <input type="checkbox" name="patreon-extend-cookie-login" value="1"<?php checked(get_option('patreon-enable-allow-admins-login-with-patreon', false)); ?> />
+                                            </td>
+                                        </tr>
+                                        <?php } ?>
 
                                         <tr valign="top">
                                             <th scope="row">


### PR DESCRIPTION
Problem:
User complaint that Patreon Auth mentods requies you to sign in eveytime you wish to view patreon gated content.

Solution:
Let site Admins opt into allowing Patreon Auth to be tied to Site default Cookie Auth expirations if remember me is selected 