### PR TITLE
Only mark credentials invalid on HTTP 401 from Patreon API

### DIFF
--- a/classes/patreon_api_v2.php
+++ b/classes/patreon_api_v2.php
@@ -58,7 +58,7 @@ class Patreon_API
 
     public function fetch_creator_info()
     {
-        $api_return = $this->__get_json('campaigns?include=creator&fields[campaign]=created_at,creation_name,discord_server_id,image_small_url,image_url,is_charged_immediately,is_monthly,is_nsfw,main_video_embed,main_video_url,one_liner,one_liner,patron_count,pay_per_name,pledge_url,published_at,summary,thanks_embed,thanks_msg,thanks_video_url,has_rss,has_sent_rss_notify,rss_feed_title,rss_artwork_url,patron_count,discord_server_id,google_analytics_id&fields[user]=about,created,email,first_name,full_name,image_url,last_name,social_connections,thumb_url,url,vanity,is_email_verified');
+        $api_return = $this->__get_json('campaigns?include=creator&fields[campaign]=created_at,creation_name,discord_server_id,image_small_url,image_url,is_charged_immediately,is_monthly,is_nsfw,main_video_embed,main_video_url,one_liner,one_liner,patron_count,pay_per_name,pledge_url,published_at,summary,thanks_embed,thanks_msg,thanks_video_url,has_rss,has_sent_rss_notify,rss_feed_title,rss_artwork_url,patron_count,discord_server_id,google_analytics_id&fields[user]=about,created,email,first_name,full_name,image_url,last_name,social_connections,thumb_url,url,vanity,is_email_verified', ['include_http_status' => true]);
 
         return $api_return;
     }
@@ -456,7 +456,12 @@ class Patreon_API
             return $response;
         }
 
-        // Return json decoded response body by default
-        return json_decode($response['body'], true);
+        $decoded = json_decode($response['body'], true) ?? [];
+
+        if (isset($args['include_http_status'])) {
+            $decoded['http_status_code'] = $response['response']['code'];
+        }
+
+        return $decoded;
     }
 }

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -1432,6 +1432,9 @@ class Patreon_Wordpress
             $api_client = new Patreon_API($creator_access_token);
             $creator_response = $api_client->fetch_creator_info();
 
+            $http_status = $creator_response['http_status_code'] ?? null;
+            $is_auth_failure = 401 == $http_status;
+
             $creator_access = false;
 
             if (isset($creator_response['included'][0]['id']) and '' != $creator_response['included'][0]['id']) {
@@ -1439,8 +1442,9 @@ class Patreon_Wordpress
                 $creator_access = true;
             }
 
-            // Try to do a creator's token refresh
-            if (!$creator_access and $tokens = self::refresh_creator_access_token()) {
+            // Only attempt a token refresh for auth failures, not for temporary
+            // issues like rate limiting or server errors
+            if (!$creator_access and $is_auth_failure and $tokens = self::refresh_creator_access_token()) {
                 // Try again:
                 $api_client = new Patreon_API($tokens['access_token']);
                 $creator_response = $api_client->fetch_creator_info();
@@ -1461,10 +1465,13 @@ class Patreon_Wordpress
 
                 return true;
             }
-        }
 
-        // All flopped. Set failure flag
-        PatreonApiUtil::set_app_creds_invalid();
+            // Only mark credentials invalid for auth failures, not temporary
+            // issues like rate limiting or server errors
+            if ($is_auth_failure) {
+                PatreonApiUtil::set_app_creds_invalid();
+            }
+        }
 
         return false;
     }


### PR DESCRIPTION
### Problem
A 429 response during `fetch_creator_info` call can result with the credentials being
marked invalid.

### Solution
- Mark the credentials invalid only if the response status code was `401`.
- Update `__get_json` to optionally include the http response status code