### PR TITLE
Add cooldown to check_creator_tiers and fix has-tiers option type

### DIFF
--- a/classes/patreon_frontend.php
+++ b/classes/patreon_frontend.php
@@ -354,7 +354,7 @@ class Patreon_Frontend
 
         $creator_url .= $append_with.$utm_params;
 
-        if ('yes' == get_option('patreon-creator-has-tiers', 'yes')) {
+        if (PatreonCreatorUtil::creator_has_tiers()) {
             // Get Patreon creator tiers
 
             $tiers = get_option('patreon-creator-tiers', false);
@@ -1158,7 +1158,7 @@ class Patreon_Frontend
             }
         }
 
-        if ('yes' == get_option('patreon-creator-has-tiers', 'yes')) {
+        if (PatreonCreatorUtil::creator_has_tiers()) {
             // Get Patreon creator tiers
 
             $tiers = get_option('patreon-creator-tiers', false);

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -66,7 +66,7 @@ class Patreon_Wordpress
 
         add_action('wp_head', [$this, 'updatePatreonUser'], 10);
         add_action('init', [$this, 'checkPatreonCreatorID']);
-        add_action('admin_init', [$this, 'check_creator_tiers']);
+        add_action('admin_init', [$this, 'check_creator_tiers_admin_init']);
         add_action('init', [$this, 'check_post_sync_webhook']);
         add_action('init', [&$this, 'order_independent_actions_to_run_on_init_start'], 0);
         add_action('init', [$this, 'check_plugin_activation_date_for_existing_installs']);
@@ -346,19 +346,22 @@ class Patreon_Wordpress
         }
     }
 
-    public static function check_creator_tiers()
+    public static function check_creator_tiers_admin_init()
     {
-        // Check if creator tier info doesnt exist. This will make sure the new version is compatible with existing installs and will show the tiers in locked interface text from the get go
+        // Refreshes creator tier info if it is missing or invalid. A cooldown
+        // prevents hitting the API on every admin page load. Tiers may be
+        // missing if they were never fetched, or if a previous fetch failed
+        // (e.g. due to a 429) and saved an empty result — in that case we retry
+        // after the cooldown to recover correctly.
 
-        // When we move to webhooks, this code can be changed to read from the already present creator details
+        // When we move to webhooks, this code can be changed to read from the
+        // already present creator details
 
         $creator_tiers = get_option('patreon-creator-tiers', false);
 
         if (!$creator_tiers or '' == $creator_tiers or !is_array($creator_tiers['included'][1])) {
-            // Refresh tiers if this is not a lite plan. We dont want this on every page load.
-
-            if (get_option('patreon-creator-has-tiers', 'yes')) {
-                // Trigger an update of creator tiers
+            if (!PatreonApiUtil::get_check_creator_tiers_cooldown()) {
+                PatreonApiUtil::set_check_creator_tiers_cooldown();
                 self::update_creator_tiers_from_api();
             }
         }
@@ -766,7 +769,7 @@ class Patreon_Wordpress
     {
         // Exception - for lite tier creators, use currently_entitled_amount_cents until there is a better way to match custom $ without tiers to local info:
 
-        if ('no' == get_option('patreon-creator-has-tiers', 'yes')) {
+        if (!PatreonCreatorUtil::creator_has_tiers()) {
             if (isset($pledge['attributes']['amount_cents'])) {
                 return $pledge['attributes']['amount_cents'];
             }
@@ -2407,11 +2410,11 @@ class Patreon_Wordpress
             array_walk_recursive($creator_info, 'self::format_creator_info_array');
 
             update_option('patreon-creator-tiers', $creator_info);
-            update_option('patreon-creator-has-tiers', 'yes');
+            update_option('patreon-creator-has-tiers', true);
         } else {
             // Creator doesnt have tiers. Save empty array so local checker functions can know there are no tiers
             update_option('patreon-creator-tiers', []);
-            update_option('patreon-creator-has-tiers', 'no');
+            update_option('patreon-creator-has-tiers', false);
         }
     }
 

--- a/includes/patreon_api_util.php
+++ b/includes/patreon_api_util.php
@@ -45,6 +45,16 @@ class PatreonApiUtil
         set_transient(self::CHECK_API_CONNECTION_COOLDOWN_KEY, true, PATREON_CHECK_API_CONNECTION_COOLDOWN_S);
     }
 
+    public static function get_check_creator_tiers_cooldown()
+    {
+        return get_transient('patreon-check-creator-tiers-cooldown');
+    }
+
+    public static function set_check_creator_tiers_cooldown()
+    {
+        set_transient('patreon-check-creator-tiers-cooldown', true, PATREON_CHECK_CREATOR_TIERS_COOLDOWN_S);
+    }
+
     private static function get_patreon_ua()
     {
         $campaign_id = get_option('patreon-campaign-id', '?');

--- a/includes/patreon_creator_util.php
+++ b/includes/patreon_creator_util.php
@@ -1,0 +1,12 @@
+<?php
+
+class PatreonCreatorUtil
+{
+    public static function creator_has_tiers()
+    {
+        $value = get_option('patreon-creator-has-tiers', true);
+
+        // Handle legacy 'yes'/'no' string values from older installs
+        return $value && 'no' !== $value;
+    }
+}

--- a/patreon.php
+++ b/patreon.php
@@ -146,6 +146,7 @@ define('PATREON_WARNING_IMPORTANT', 'Important: ');
 define('PATREON_WARNING_POST_SYNC_SET_WITHOUT_API_V2', 'Important: Post syncing from Patreon is set to on, but your site is using API v1. Post sync wont work without API v2. Follow <a href="https://www.patreondevelopers.com/t/how-to-upgrade-your-patreon-wordpress-to-use-api-v2/3249" target="_blank">this guide</a> to upgrade your site to API v2 or disable post sync <a href="'.admin_url('admin.php?page=patreon-plugin').'">here in settings</a>');
 define('PATREON_CHECK_API_CONNECTION_COOLDOWN_S', 10 * 60);
 define('PATREON_CREATOR_TOKEN_REFRESH_ATTEMPT_COOLDOWN_S', 60);
+define('PATREON_CHECK_CREATOR_TIERS_COOLDOWN_S', 5 * 60);
 
 require 'classes/patreon_wordpress.php';
 
@@ -155,3 +156,4 @@ $Patreon_Wordpress = new Patreon_Wordpress();
 
 require 'includes/patreon_widgets.php';
 require 'includes/patreon_api_util.php';
+require 'includes/patreon_creator_util.php';


### PR DESCRIPTION
### Problem
`check_creator_tiers()` runs on every admin page load via `admin_init`.
When the `patreon-creator-tiers` option was missing or invalid, it would call
`fetch_tiers()` - hitting `/oauth2/v2/campaigns` on every single admin request
with no rate limiting or cooldown.

This was made worse by a bug where the `patreon-creator-has-tiers` option
was stored as the string `'no'` for creators without tiers. Since `'no'` is truthy
in PHP, the guard meant to skip the API call for no-tier creators never worked,
causing those sites to hit the API on every admin load indefinitely.

On a busy site this results in a high volume of requests to `/oauth2/v2/campaigns`
in a short period, which can trigger Patreon's rate limiting and cause HTTP 429
responses.

### Solution
1. Cooldown: Added a 5-minute transient-based cooldown to `check_creator_tiers()`.
If the API was called recently, subsequent admin page loads skip the call until the
cooldown expires.
2. Boolean fix: Changed `patreon-creator-has-tiers` to store `true/false` instead of
`'yes'/'no'`.
3. Backwards compatibility: Introduced `PatreonCreatorUtil::creator_has_tiers()`
to centralise reading of this option across the codebase, correctly handling legacy
`'yes'/'no'` string values that may still be present in existing installs. Note: this helper
intentionally does not gate the API refetch in `check_creator_tiers_admin_init` -
tiers may have been incorrectly saved as empty due to a transient error (e.g. a 429),
so we always retry on cooldown expiry to allow recovery.
