### PR TITLE
Remove isset call when checking for existing cached placeholder image

### DIFF
--- a/classes/patreon_protect.php
+++ b/classes/patreon_protect.php
@@ -307,7 +307,7 @@ class Patreon_Protect
 
         // first, check if cached image exists:
 
-        if (file_exists(PATREON_PLUGIN_LOCKED_IMAGE_CACHE_DIR.'/'.$cached_filename) and isset($go)) {
+        if (file_exists(PATREON_PLUGIN_LOCKED_IMAGE_CACHE_DIR.'/'.$cached_filename)) {
             // Exists - serve the cached image:
 
             header('Content-Type: '.$mime_type);


### PR DESCRIPTION
The protected image placeholder is always generated on each request instead of using the previously cached file.

In patreon_protect.php, the file_exists check for the previously generated file has additional call to isset($go). This will always return false, forcing the image to be regenerated each time rather than reusing the existing cached file.