### PR TITLE
Fix OAuth session collision overwriting admin identity

### DIFF
--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -166,7 +166,7 @@ class Patreon_Login
         }
     }
 
-    public static function createOrLogInUserFromPatreon($user_response, $tokens, $redirect = false)
+    public static function createOrLogInUserFromPatreon($user_response, $tokens, $redirect = false, $state = [])
     {
         global $wpdb;
 
@@ -176,8 +176,9 @@ class Patreon_Login
 
         // Check if user is logged in to wp:
 
-        // Logged in user. We just link the user up and be done.
-        if (is_user_logged_in()) {
+        // Logged in user. Only link if the OAuth flow nonce confirms this user initiated the flow.
+        // If verification fails, fall through to the not-logged-in path (lookup/create).
+        if (is_user_logged_in() && self::verify_oauth_flow_nonce($state)) {
             $user = wp_get_current_user();
 
             self::updateExistingUser($user->ID, $user_response, $tokens);

--- a/classes/patreon_login.php
+++ b/classes/patreon_login.php
@@ -23,6 +23,67 @@ class Patreon_Login
         delete_user_meta($user_id, 'patreon_token_minted');
     }
 
+    /**
+     * Generate an OAuth flow nonce for the current user and store it as a transient.
+     * Returns an array with 'nonce' and 'user_id' to embed in the OAuth state parameter.
+     * If no user is logged in, returns an empty array.
+     */
+    public static function generate_oauth_flow_nonce()
+    {
+        if (!is_user_logged_in()) {
+            return [];
+        }
+
+        $user_id = get_current_user_id();
+        $nonce = wp_generate_password(32, false);
+        $transient_key = 'patreon_oauth_nonce_' . $user_id;
+
+        // Store nonce with 10-minute TTL
+        set_transient($transient_key, $nonce, 10 * MINUTE_IN_SECONDS);
+
+        return [
+            'oauth_nonce' => $nonce,
+            'oauth_user_id' => $user_id,
+        ];
+    }
+
+    /**
+     * Verify that the OAuth flow nonce in the state parameter matches the logged-in user.
+     * Returns true if the nonce is valid and belongs to the current user, false otherwise.
+     */
+    public static function verify_oauth_flow_nonce($state)
+    {
+        if (!is_user_logged_in()) {
+            return false;
+        }
+
+        if (!isset($state['oauth_nonce']) || !isset($state['oauth_user_id'])) {
+            return false;
+        }
+
+        $user_id = get_current_user_id();
+
+        // The state must claim to belong to the currently logged-in user
+        if ((int) $state['oauth_user_id'] !== $user_id) {
+            return false;
+        }
+
+        $transient_key = 'patreon_oauth_nonce_' . $user_id;
+        $stored_nonce = get_transient($transient_key);
+
+        if (false === $stored_nonce) {
+            return false;
+        }
+
+        // Constant-time comparison
+        $valid = hash_equals($stored_nonce, $state['oauth_nonce']);
+
+        // Delete the transient after use (one-time use nonce)
+        delete_transient($transient_key);
+
+        return $valid;
+    }
+
     public static function updateExistingUser($user_id, $user_response, $tokens)
     {
         /* update user meta data with patreon data */

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -595,7 +595,8 @@ class Patreon_Routing
                 if (apply_filters('ptrn/force_strict_oauth', get_option('patreon-enable-strict-oauth', false))) {
                     $user = Patreon_Login::updateLoggedInUserForStrictoAuth($user_response, $tokens, $redirect);
                 } else {
-                    $user = Patreon_Login::createOrLogInUserFromPatreon($user_response, $tokens, $redirect);
+                    $state_for_login = isset($state) ? $state : [];
+                    $user = Patreon_Login::createOrLogInUserFromPatreon($user_response, $tokens, $redirect, $state_for_login);
                 }
 
                 // shouldn't get here

--- a/classes/patreon_routing.php
+++ b/classes/patreon_routing.php
@@ -80,6 +80,9 @@ class Patreon_Routing
                     'final_redirect_uri' => $final_redirect,
                 ];
 
+                // Embed OAuth flow nonce so the callback can verify which user initiated this flow
+                $state = array_merge($state, Patreon_Login::generate_oauth_flow_nonce());
+
                 // Below filter vars and the following filter allows plugin devs to acquire/filter info about Patron/user + content before going to Patreon flow
 
                 $filter_args = [
@@ -127,6 +130,9 @@ class Patreon_Routing
                     $link_interface_item = 'direct_unlock_button';
                     $state['final_redirect_uri'] = $redirect;
                     $send_pledge_level = $patreon_level * 100;
+
+                    // Embed OAuth flow nonce so the callback can verify which user initiated this flow
+                    $state = array_merge($state, Patreon_Login::generate_oauth_flow_nonce());
 
                     $flow_link = Patreon_Frontend::MakeUniversalFlowLink($send_pledge_level, $state, $client_id, $post, ['link_interface_item' => $link_interface_item]);
 
@@ -211,6 +217,9 @@ class Patreon_Routing
                     }
 
                     $state['final_redirect_uri'] = $final_redirect;
+
+                    // Embed OAuth flow nonce so the callback can verify which user initiated this flow
+                    $state = array_merge($state, Patreon_Login::generate_oauth_flow_nonce());
 
                     $send_pledge_level = $patreon_level * 100;
 

--- a/classes/patreon_user_profiles.php
+++ b/classes/patreon_user_profiles.php
@@ -39,15 +39,15 @@ class Patreon_User_Profiles
                     </td>
                 </tr>
                 <tr>
-                    <th><label for="user_firstname"><?php _e('Patreon First name'); ?></label></th>
+                    <th><label for="patreon_user_firstname"><?php _e('Patreon First name'); ?></label></th>
                     <td>
-                        <input type="text" name="user_firstname" id="user_firstname" disabled value="<?php echo esc_attr(get_the_author_meta('user_firstname', $user->ID)); ?>" class="regular-text" /><br />
+                        <input type="text" name="patreon_user_firstname" id="patreon_user_firstname" disabled value="<?php echo esc_attr(get_user_meta($user->ID, 'patreon_user_firstname', true)); ?>" class="regular-text" /><br />
                     </td>
                 </tr>
                 <tr>
-                    <th><label for="user_lastname"><?php _e('Patreon Last name'); ?></label></th>
+                    <th><label for="patreon_user_lastname"><?php _e('Patreon Last name'); ?></label></th>
                     <td>
-                        <input type="text" name="user_lastname" id="user_lastname" disabled value="<?php echo esc_attr(get_the_author_meta('user_lastname', $user->ID)); ?>" class="regular-text" /><br />
+                        <input type="text" name="patreon_user_lastname" id="patreon_user_lastname" disabled value="<?php echo esc_attr(get_user_meta($user->ID, 'patreon_user_lastname', true)); ?>" class="regular-text" /><br />
                     </td>
                 </tr>
             </table>

--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -319,8 +319,8 @@ class Patreon_Wordpress
             }
 
             update_user_meta($user->ID, 'patreon_created', $patreon_created);
-            update_user_meta($user->ID, 'user_firstname', $user_response['data']['attributes']['first_name']);
-            update_user_meta($user->ID, 'user_lastname', $user_response['data']['attributes']['last_name']);
+            update_user_meta($user->ID, 'patreon_user_firstname', $user_response['data']['attributes']['first_name']);
+            update_user_meta($user->ID, 'patreon_user_lastname', $user_response['data']['attributes']['last_name']);
         }
     }
 


### PR DESCRIPTION
## Problem

https://www.patreondevelopers.com/t/admin-display-name-nickname-changing-when-patreon-members-join/11295

The OAuth callback in `createOrLogInUserFromPatreon()` links the incoming Patreon identity to whoever is currently logged into WordPress — not necessarily the user who started the flow. If an admin is logged in when a different Patreon account completes OAuth in the same browser, the admin's Patreon identity and display name get overwritten.

Additionally, `updatePatreonUser()` writes Patreon names into WordPress's built-in `user_firstname`/`user_lastname` meta keys, silently replacing the user's WordPress profile name.

## Fix

- Add a one-time nonce to the OAuth `state` parameter, verified on callback before linking to a logged-in user. Mismatches fall through to the standard lookup/create path.
- Rename `user_firstname`/`user_lastname` to `patreon_user_firstname`/`patreon_user_lastname` so Patreon sync doesn't collide with WordPress profile fields.

## Test plan

- [ ] Admin connects own Patreon account — identity links correctly, WP display name unchanged
- [ ] Admin logged in + different Patreon account completes OAuth in same browser — admin's `patreon_user_id` is NOT overwritten
- [ ] Patron logs in via Patreon (not logged into WP) — correct user created/found
- [ ] Patreon First/Last name fields display correctly in user profile; WP First/Last name fields are not overwritten by Patreon sync
- [ ] Nonce expiration (>10 min delay) — falls through to lookup/create path instead of linking
- [ ] Direct-unlock and post-unlock flows work for both logged-in and logged-out users