### PR TITLE
Fix null reference error in pledge objects filling up Apache error logs.

### DIFF
--- a/classes/patreon_wordpress.php
+++ b/classes/patreon_wordpress.php
@@ -780,7 +780,8 @@ class Patreon_Wordpress
         }
 
         // Get currently entitled tiers:
-
+		if(!is_array($pledge)) return 0;
+		if(empty($pledge['relationships']['currently_entitled_tiers']['data'])) return 0;
         $currently_entitled_tiers = $pledge['relationships']['currently_entitled_tiers']['data'];
 
         if (!is_array($currently_entitled_tiers)) {


### PR DESCRIPTION
The $pledge object in patreon_wordpress.php is not always filled up when data on it is accessed. We need to check whether it is filled before using it.